### PR TITLE
Ops: Enable cross-platform CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,18 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      contents: write
 
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Setup environment
       uses: ./.github/actions/setup-environment
 
     - name: Build ClojureScript
       run: npm run build
-      
+
     - name: Publish App
       run: npx electron-forge publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,8 @@ jobs:
     - name: Setup environment
       uses: ./.github/actions/setup-environment
 
+    - name: Build ClojureScript
+      run: npm run build
+      
     - name: Publish App
       run: npx electron-forge publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ jobs:
 
   build:
     needs: test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gremllm",
   "version": "0.1.0",
   "description": "An Experimental IDE (Idea Development Environment)",
+  "license": "MIT",
   "main": "target/main.js",
   "scripts": {
     "dev": "concurrently \"shadow-cljs watch main-dev renderer\" \"sleep 10 && ELECTRON_IS_DEV=1 electron-forge start\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gremllm",
   "version": "0.1.0",
+  "description": "An Experimental IDE (Idea Development Environment)",
   "main": "target/main.js",
   "scripts": {
     "dev": "concurrently \"shadow-cljs watch main-dev renderer\" \"sleep 10 && ELECTRON_IS_DEV=1 electron-forge start\"",

--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
-  "name": "gremllm",
-  "version": "0.1.0",
-  "description": "An Experimental IDE (Idea Development Environment)",
-  "license": "MIT",
-  "main": "target/main.js",
-  "scripts": {
-    "dev": "concurrently \"shadow-cljs watch main-dev renderer\" \"sleep 10 && ELECTRON_IS_DEV=1 electron-forge start\"",
-    "build": "npm run clean && shadow-cljs compile main renderer",
-    "package": "npm run build && electron-forge package",
-    "make": "npm run build && electron-forge make",
-    "repl": "shadow-cljs cljs-repl renderer",
-    "clean": "rm -rf .shadow-cljs target resources/public/compiled-js",
-    "test": "shadow-cljs compile test",
-    "test:watch": "shadow-cljs watch test"
-  },
-  "devDependencies": {
-    "@electron-forge/cli": "^7.8.1",
-    "@electron-forge/maker-deb": "^7.8.1",
-    "@electron-forge/maker-rpm": "^7.8.1",
-    "@electron-forge/maker-squirrel": "^7.8.1",
-    "@electron-forge/maker-zip": "^7.8.1",
-    "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
-    "@electron-forge/plugin-fuses": "^7.8.1",
-    "@electron-forge/publisher-github": "^7.8.1",
-    "@electron/fuses": "^1.8.0",
-    "concurrently": "^9.2.0",
-    "electron": "^37.2.2",
-    "electron-reload": "^2.0.0-alpha.1",
-    "shadow-cljs": "^3.1.7"
-  },
-  "dependencies": {
-    "@dotenvx/dotenvx": "^1.47.6"
-  }
+	"name": "gremllm",
+	"version": "0.1.0",
+	"description": "An Experimental IDE (Idea Development Environment)",
+	"license": "MIT",
+	"author": "Quantisan, LLC",
+	"main": "target/main.js",
+	"scripts": {
+		"dev": "concurrently \"shadow-cljs watch main-dev renderer\" \"sleep 10 && ELECTRON_IS_DEV=1 electron-forge start\"",
+		"build": "npm run clean && shadow-cljs compile main renderer",
+		"package": "npm run build && electron-forge package",
+		"make": "npm run build && electron-forge make",
+		"repl": "shadow-cljs cljs-repl renderer",
+		"clean": "rm -rf .shadow-cljs target resources/public/compiled-js",
+		"test": "shadow-cljs compile test",
+		"test:watch": "shadow-cljs watch test"
+	},
+	"devDependencies": {
+		"@electron-forge/cli": "^7.8.1",
+		"@electron-forge/maker-deb": "^7.8.1",
+		"@electron-forge/maker-rpm": "^7.8.1",
+		"@electron-forge/maker-squirrel": "^7.8.1",
+		"@electron-forge/maker-zip": "^7.8.1",
+		"@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
+		"@electron-forge/plugin-fuses": "^7.8.1",
+		"@electron-forge/publisher-github": "^7.8.1",
+		"@electron/fuses": "^1.8.0",
+		"concurrently": "^9.2.0",
+		"electron": "^37.2.2",
+		"electron-reload": "^2.0.0-alpha.1",
+		"shadow-cljs": "^3.1.7"
+	},
+	"dependencies": {
+		"@dotenvx/dotenvx": "^1.47.6"
+	}
 }


### PR DESCRIPTION
This PR updates the GitHub Actions build workflow to run across Ubuntu, Windows, and macOS, ensuring the application is built before publishing. It adds an explicit `npm run build` step and adjusts GITHUB_TOKEN permissions for content writing. Additionally, `package.json` now includes project description, license, and author details.