### PR TITLE
Feat/ipc encryption availablility flag

### DIFF
--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -51,6 +51,4 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	loadSecret: (key) => ipcRenderer.invoke("secrets/load", key),
 	deleteSecret: (key) => ipcRenderer.invoke("secrets/delete", key),
 	listSecretKeys: () => ipcRenderer.invoke("secrets/list-keys"),
-	checkSecretsAvailability: () =>
-		ipcRenderer.invoke("secrets/check-availability"),
 });

--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -2,14 +2,14 @@ const { contextBridge, ipcRenderer } = require("electron/renderer");
 
 /**
  * Creates a promise-based wrapper for Electron's event-based IPC.
- * 
- * Problem: The renderer needs to know when async operations in the main 
- * process complete (e.g., API calls, file saves), but Electron IPC is 
+ *
+ * Problem: The renderer needs to know when async operations in the main
+ * process complete (e.g., API calls, file saves), but Electron IPC is
  * fire-and-forget between processes.
- * 
+ *
  * Solution: Use unique IDs to create temporary request-response channels.
- * 
- * This is boundary code - it creates the illusion of RPC (remote procedure 
+ *
+ * This is boundary code - it creates the illusion of RPC (remote procedure
  * calls) over Electron's event-based IPC.
  */
 const createIPCBoundary = (channel) => {
@@ -17,19 +17,19 @@ const createIPCBoundary = (channel) => {
 		return new Promise((resolve, reject) => {
 			// Use standard UUID for request-response matching
 			const requestId = crypto.randomUUID();
-			
+
 			// Set up one-time listeners for this request
 			const successChannel = `${channel}-success-${requestId}`;
 			const errorChannel = `${channel}-error-${requestId}`;
-			
+
 			ipcRenderer.once(successChannel, (event, result) => {
 				resolve(result);
 			});
-			
+
 			ipcRenderer.once(errorChannel, (event, error) => {
 				reject(new Error(error));
 			});
-			
+
 			// Send request with ID so main process knows where to reply
 			ipcRenderer.send(channel, requestId, ...args);
 		});
@@ -42,9 +42,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	loadTopic: () => ipcRenderer.invoke("topic/load"),
 	onMenuCommand: (command, callback) => ipcRenderer.on(command, callback),
 	onSystemInfo: (callback) => {
-		console.log("[PRELOAD] Setting up system:info listener");
 		ipcRenderer.on("system:info", (event, systemInfo) => {
-			console.log("[PRELOAD] Received system:info:", systemInfo);
 			callback(systemInfo);
 		});
 	},
@@ -53,5 +51,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	loadSecret: (key) => ipcRenderer.invoke("secrets/load", key),
 	deleteSecret: (key) => ipcRenderer.invoke("secrets/delete", key),
 	listSecretKeys: () => ipcRenderer.invoke("secrets/list-keys"),
-	checkSecretsAvailability: () => ipcRenderer.invoke("secrets/check-availability"),
+	checkSecretsAvailability: () =>
+		ipcRenderer.invoke("secrets/check-availability"),
 });

--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -41,6 +41,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	saveTopic: (topicData) => ipcRenderer.invoke("topic/save", topicData),
 	loadTopic: () => ipcRenderer.invoke("topic/load"),
 	onMenuCommand: (command, callback) => ipcRenderer.on(command, callback),
+	onSystemInfo: (callback) => {
+		ipcRenderer.on("system:info", (event, systemInfo) => {
+			callback(systemInfo);
+		});
+	},
 	// Secrets API
 	saveSecret: (key, value) => ipcRenderer.invoke("secrets/save", key, value),
 	loadSecret: (key) => ipcRenderer.invoke("secrets/load", key),

--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -42,7 +42,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	loadTopic: () => ipcRenderer.invoke("topic/load"),
 	onMenuCommand: (command, callback) => ipcRenderer.on(command, callback),
 	onSystemInfo: (callback) => {
+		console.log("[PRELOAD] Setting up system:info listener");
 		ipcRenderer.on("system:info", (event, systemInfo) => {
+			console.log("[PRELOAD] Received system:info:", systemInfo);
 			callback(systemInfo);
 		});
 	},

--- a/src/gremllm/main/actions.cljs
+++ b/src/gremllm/main/actions.cljs
@@ -51,4 +51,3 @@
 (nxr/register-effect! :secrets.effects/load secrets-actions/load)
 (nxr/register-effect! :secrets.effects/delete secrets-actions/del)
 (nxr/register-effect! :secrets.effects/list-keys secrets-actions/list-keys)
-(nxr/register-effect! :secrets.effects/check-availability (fn [_ _ _] (secrets-actions/check-availability)))

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -80,7 +80,6 @@
 (defn main []
   (let [store (atom {})
         system-info (get-system-info)]
-    (println "[MAIN] System info at startup:" system-info)
     (setup-api-handlers store)
     (-> (.whenReady app)
         (.then (fn []

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -19,7 +19,9 @@
 
     ;; Push system info after window loads
     (.once (.-webContents win) "did-finish-load"
-           #(.send (.-webContents win) "system:info" (clj->js system-info)))
+           (fn []
+             (println "[MAIN] Sending system:info:" system-info)
+             (.send (.-webContents win) "system:info" (clj->js system-info))))
 
     win))
 
@@ -78,6 +80,7 @@
 (defn main []
   (let [store (atom {})
         system-info (get-system-info)]
+    (println "[MAIN] System info at startup:" system-info)
     (setup-api-handlers store)
     (-> (.whenReady app)
         (.then (fn []

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -69,13 +69,7 @@
   (.handle ipcMain "secrets/list-keys"
            (fn [_event]
              (let [dispatch-result (nxr/dispatch store {} [[:secrets.effects/list-keys]])]
-               (nxr-result dispatch-result))))
-
-  (.handle ipcMain "secrets/check-availability"
-           (fn [_event]
-             (let [dispatch-result (nxr/dispatch store {} [[:secrets.effects/check-availability]])]
                (nxr-result dispatch-result)))))
-
 
 (defn main []
   (let [store (atom {})

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -2,7 +2,8 @@
   (:require [nexus.registry :as nxr]
             [gremllm.renderer.actions.ui :as ui]        ; UI interactions
             [gremllm.renderer.actions.messages :as msg]  ; Message handling
-            [gremllm.renderer.actions.topic :as topic]))   ; Topic persistence
+            [gremllm.renderer.actions.topic :as topic]
+            [gremllm.renderer.actions.system :as system]))
 
 ;; Set up how to extract state from your atom
 (nxr/register-system->state! deref)
@@ -56,3 +57,6 @@
 (nxr/register-action! :topic.actions/load-error topic/load-topic-error)
 (nxr/register-action! :topic.actions/save-success topic/save-topic-success)
 (nxr/register-action! :topic.actions/save-error topic/save-topic-error)
+
+(nxr/register-action! :system.actions/set-info system/set-info)
+

--- a/src/gremllm/renderer/actions/system.cljs
+++ b/src/gremllm/renderer/actions/system.cljs
@@ -1,0 +1,6 @@
+(ns gremllm.renderer.actions.system
+  (:require [gremllm.renderer.state.system :as system-state]))
+
+(defn set-info [_state system-info]
+  [[:effects/save system-state/system-info-path system-info]])
+

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -27,8 +27,8 @@
 
     ;; Render on every change
     (add-watch store ::render-topic
-               (fn [_ _ _ topic]
-                 (->> topic
+               (fn [_ _ _ state]
+                 (->> state
                       (ui/render-app)
                       (r/render el))))
 

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -22,7 +22,9 @@
 
     (.onSystemInfo js/window.electronAPI
                    (fn [system-info-js]
+                     (println "[RENDERER] Received system info (raw):" system-info-js)
                      (let [system-info (js->clj system-info-js :keywordize-keys true)]
+                       (println "[RENDERER] Converted system info:" system-info)
                        (nxr/dispatch store {} [[:system.actions/set-info system-info]]))))
 
     ;; Render on every change

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -20,6 +20,11 @@
                     (fn []
                       (nxr/dispatch store {} [[:ui.actions/show-settings]])))
 
+    (.onSystemInfo js/window.electronAPI
+                   (fn [system-info-js]
+                     (let [system-info (js->clj system-info-js :keywordize-keys true)]
+                       (nxr/dispatch store {} [[:system.actions/set-info system-info]]))))
+
     ;; Render on every change
     (add-watch store ::render-topic
                (fn [_ _ _ topic]

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -22,9 +22,7 @@
 
     (.onSystemInfo js/window.electronAPI
                    (fn [system-info-js]
-                     (println "[RENDERER] Received system info (raw):" system-info-js)
                      (let [system-info (js->clj system-info-js :keywordize-keys true)]
-                       (println "[RENDERER] Converted system info:" system-info)
                        (nxr/dispatch store {} [[:system.actions/set-info system-info]]))))
 
     ;; Render on every change

--- a/src/gremllm/renderer/state/system.cljs
+++ b/src/gremllm/renderer/state/system.cljs
@@ -1,0 +1,7 @@
+(ns gremllm.renderer.state.system)
+
+(def system-info-path [:system :info])
+
+(defn encryption-available? [state]
+  (get-in state (conj system-info-path :encryption-available?) false))
+

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -3,6 +3,7 @@
             [gremllm.renderer.state.form :as form-state]
             [gremllm.renderer.state.loading :as loading-state]
             [gremllm.renderer.state.ui :as ui-state]
+            [gremllm.renderer.state.system :as system-state]
             [gremllm.renderer.ui.settings :as settings-ui]))
 
 (defn render-user-message [message]
@@ -83,4 +84,7 @@
                         has-api-key?)
 
      ;; TODO: pass in actual values
-     (settings-ui/render-settings-modal (ui-state/showing-settings? topic) false false)]))
+     (settings-ui/render-settings-modal
+       (ui-state/showing-settings? topic)
+       (system-state/encryption-available? topic)
+       false)]))

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -64,8 +64,8 @@
      [:button {:type "submit"
                :disabled (or loading? (not has-api-key?))} "Send"]]]])
 
-(defn render-app [topic]
-  (let [has-api-key? false] ;; TODO: need to check on bootup in main process
+(defn render-app [state]
+  (let [has-api-key? false] ;; TODO: pass in actual value
     [:div {:style {:display "flex"
                    :flex-direction "column"
                    :height "100vh"}}
@@ -76,15 +76,14 @@
      (when-not has-api-key?
        (settings-ui/render-api-key-warning))
 
-     (render-chat-area (msg-state/get-messages topic)
-                       (loading-state/get-loading topic)
-                       (loading-state/get-assistant-errors topic))
-     (render-input-form (form-state/get-user-input topic)
-                        (loading-state/loading? topic)
+     (render-chat-area (msg-state/get-messages state)
+                       (loading-state/get-loading state)
+                       (loading-state/get-assistant-errors state))
+     (render-input-form (form-state/get-user-input state)
+                        (loading-state/loading? state)
                         has-api-key?)
 
-     ;; TODO: pass in actual values
      (settings-ui/render-settings-modal
-       (ui-state/showing-settings? topic)
-       (system-state/encryption-available? topic)
-       false)]))
+       (ui-state/showing-settings? state)
+       (system-state/encryption-available? state)
+       has-api-key?)]))


### PR DESCRIPTION
The main process now collects system information (including encryption availability) and pushes it to the renderer after the window finishes loading, eliminating the need for the renderer to request this information.