### PR TITLE
refactor: Rework state management to support multiple topics

### DIFF
--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -64,6 +64,7 @@
 (nxr/register-action! :topic.actions/bootstrap topic/bootstrap)
 (nxr/register-action! :topic.actions/restore-or-create-topic topic/restore-or-create-topic)
 (nxr/register-action! :topic.actions/start-new topic/start-new-topic)
+(nxr/register-action! :topic.actions/switch-to topic/switch-topic)
 (nxr/register-action! :topic.actions/load-error topic/load-topic-error)
 (nxr/register-action! :topic.actions/save-success topic/save-topic-success)
 (nxr/register-action! :topic.actions/save-error topic/save-topic-error)

--- a/src/gremllm/renderer/actions/messages.cljs
+++ b/src/gremllm/renderer/actions/messages.cljs
@@ -10,7 +10,7 @@
 (defn append-to-state [state message]
   (let [current-messages (topic-state/get-messages state)]
     [[:effects/save
-      (conj topic-state/path :messages)
+      (conj topic-state/topics-path :messages)
       (conj current-messages message)]]))
 
 ;; Domain-specific actions

--- a/src/gremllm/renderer/actions/messages.cljs
+++ b/src/gremllm/renderer/actions/messages.cljs
@@ -12,7 +12,7 @@
     (let [current-messages (topic-state/get-messages state)
           path-to-messages (-> topic-state/topics-path (conj active-id :messages))]
       [[:effects/save path-to-messages (conj (or current-messages []) message)]])
-    []))
+    (throw (js/Error. "Cannot append message: no active topic."))))
 
 ;; Domain-specific actions
 (nxr/register-action! :messages.actions/append-to-state append-to-state)

--- a/src/gremllm/renderer/actions/messages.cljs
+++ b/src/gremllm/renderer/actions/messages.cljs
@@ -8,10 +8,11 @@
    [:effects/scroll-to-bottom "chat-messages-container"]])
 
 (defn append-to-state [state message]
-  (let [current-messages (topic-state/get-messages state)]
-    [[:effects/save
-      (conj topic-state/topics-path :messages)
-      (conj current-messages message)]]))
+  (if-let [active-id (topic-state/get-active-topic-id state)]
+    (let [current-messages (topic-state/get-messages state)
+          path-to-messages (-> topic-state/topics-path (conj active-id :messages))]
+      [[:effects/save path-to-messages (conj (or current-messages []) message)]])
+    []))
 
 ;; Domain-specific actions
 (nxr/register-action! :messages.actions/append-to-state append-to-state)

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -9,9 +9,12 @@
 (defn normalize-topic [topic]
   (update topic :messages #(mapv normalize-message %)))
 
+(defn get-timestamp []
+  (js/Date.now))
+
 ;; TODO: create a Malli schema for Message
 (defn create-topic []
-  {:id (str "topic-" (js/Date.now))
+  {:id (str "topic-" (get-timestamp))
    :name "New Topic"
    :messages []})
 

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -72,12 +72,13 @@
            :on-error   [:topic.actions/load-error]}]]))))
 
 (nxr/register-effect! :topic.effects/save-topic
-  (fn [{dispatch :dispatch} store topic-id]
-    (if-let [topic (get-in @store (conj topic-state/topics-path topic-id))]
-      (dispatch
-        [[:effects/promise
-          {:promise    (.saveTopic js/window.electronAPI (clj->js topic))
-           :on-success [:topic.actions/save-success topic-id]
-           :on-error   [:topic.actions/save-error topic-id]}]])
-      (dispatch [[:topic.actions/save-error topic-id (js/Error. (str "Topic not found for id: " topic-id))]]))))
+  (fn [{dispatch :dispatch} store]
+    (let [active-topic (topic-state/get-active-topic @store)]
+      (if-let [topic-id (:id active-topic)]
+        (dispatch
+         [[:effects/promise
+           {:promise    (.saveTopic js/window.electronAPI (clj->js active-topic))
+            :on-success [:topic.actions/save-success topic-id]
+            :on-error   [:topic.actions/save-error topic-id]}]])
+        (dispatch [[:topic.actions/save-error nil (js/Error. "No active topic to save")]])))))
 

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -11,7 +11,7 @@
 
 ;; TODO: create a Malli schema for Message
 (defn create-topic []
-  {:id "topic-1"
+  {:id (str "topic-" (js/Date.now))
    :name "New Topic"
    :messages []})
 
@@ -33,7 +33,9 @@
    [:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]])
 
 (defn start-new-topic [_state]
-  [[:effects/save topic-state/topics-path (create-topic)]])
+  (let [new-topic (create-topic)]
+    [[:effects/save (conj topic-state/topics-path (:id new-topic)) new-topic]
+     [:effects/save topic-state/active-topic-id-path (:id new-topic)]]))
 
 (defn load-topic-error [_state error]
   (js/console.error "load-topic failed:" error)

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -9,15 +9,17 @@
 (defn normalize-topic [topic]
   (update topic :messages #(mapv normalize-message %)))
 
-(defn get-timestamp []
-  (js/Date.now))
+(defn generate-topic-id []
+;; NOTE: We call `js/Date.now` and js/Math.random directly for pragmatic FCIS. Passing these values
+;; as argument would complicate the call stack for a benign, testable effect.
+  (let [timestamp (js/Date.now)
+        random-suffix (-> (js/Math.random) (.toString 36) (.substring 2))]
+    (str "topic-" timestamp "-" random-suffix)))
 
 ;; TODO: create a Malli schema for Message
-;; NOTE: We call `get-timestamp` directly for pragmatic FCIS. Passing a timestamp
-;; as an argument would complicate the call stack for a benign, testable effect.
 (defn create-topic []
-  {:id (str "topic-" (get-timestamp))
-   :name "New Topic"
+  {:id       (generate-topic-id)
+   :name     "New Topic"
    :messages []})
 
 (defn set-topic [_state topic-js]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -71,7 +71,7 @@
            :on-success on-success
            :on-error   [:topic.actions/load-error]}]]))))
 
-(nxr/register-effect! :topic.effects/save-topic
+(nxr/register-effect! :topic.effects/save-active-topic
   (fn [{dispatch :dispatch} store]
     (let [active-topic (topic-state/get-active-topic @store)]
       (if-let [topic-id (:id active-topic)]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -13,6 +13,8 @@
   (js/Date.now))
 
 ;; TODO: create a Malli schema for Message
+;; NOTE: We call `get-timestamp` directly for pragmatic FCIS. Passing a timestamp
+;; as an argument would complicate the call stack for a benign, testable effect.
 (defn create-topic []
   {:id (str "topic-" (get-timestamp))
    :name "New Topic"

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -58,6 +58,9 @@
   (js/console.error "save-topic (topic-id: " topic-id ") failed:" error)
   [])
 
+(defn switch-topic [_state topic-id]
+  [[:effects/save topic-state/active-topic-id-path topic-id]])
+
 ;; Effects for topic persistence
 (nxr/register-effect! :topic.effects/load-topic
   (fn [{dispatch :dispatch} _store & [opts]]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -19,7 +19,7 @@
   (when topic-js
     (let [clj-topic (js->clj topic-js :keywordize-keys true)
           normalized-topic (normalize-topic clj-topic)]
-      [[:effects/save topic-state/path normalized-topic]])))
+      [[:effects/save topic-state/topics-path normalized-topic]])))
 
 (defn restore-or-create-topic [_state loaded-topic]
   (if loaded-topic
@@ -33,7 +33,7 @@
    [:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]])
 
 (defn start-new-topic [_state]
-  [[:effects/save topic-state/path (create-topic)]])
+  [[:effects/save topic-state/topics-path (create-topic)]])
 
 (defn load-topic-error [_state error]
   (js/console.error "load-topic failed:" error)
@@ -61,7 +61,7 @@
   (fn [{dispatch :dispatch} store topic-id]
     (dispatch
       [[:effects/promise
-        {:promise    (.saveTopic js/window.electronAPI (clj->js (get-in @store topic-state/path)))
+        {:promise    (.saveTopic js/window.electronAPI (clj->js (get-in @store topic-state/topics-path)))
          :on-success [:topic.actions/save-success topic-id]
          :on-error   [:topic.actions/save-error topic-id]}]])))
 

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -10,7 +10,7 @@
         el    (js/document.getElementById "app")]
     (.onMenuCommand js/window.electronAPI "topic/save"
                     (fn []
-                      (nxr/dispatch store {} [[:topic.effects/save-topic "current-topic"]])))
+                      (nxr/dispatch store {} [[:topic.effects/save-active-topic]])))
 
     (.onMenuCommand js/window.electronAPI "topic/open"
                     (fn []

--- a/src/gremllm/renderer/state/topic.cljs
+++ b/src/gremllm/renderer/state/topic.cljs
@@ -1,7 +1,21 @@
 (ns gremllm.renderer.state.topic)
 
-(def path [:topic])
+(def topics-path [:topics])
+(def active-topic-id-path [:active-topic-id])
+
+(defn get-active-topic-id [state]
+  (get-in state active-topic-id-path))
+
+(defn get-active-topic [state]
+  (let [active-id (get-active-topic-id state)]
+    (get-in state (conj topics-path active-id))))
 
 (defn get-messages [state]
-  (get-in state (conj path :messages) []))
+  (:messages (get-active-topic state)))
+
+(defn get-topic-id [state]
+  (:id (get-active-topic state)))
+
+(defn get-topic-title [state]
+  (:title (get-active-topic state)))
 

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -19,7 +19,7 @@
       [:nav
        [:ul
         [:li [:a {:href          "#"
-                  :on-click      [[:effects/prevent-default]]
+                  :on            {:click [[:effects/prevent-default]]}
                   :aria-disabled "true"
                   :data-tooltip  "Not implemented yet"}
               "➕ New Topic"]]]]

--- a/test/gremllm/renderer/actions/messages_test.cljs
+++ b/test/gremllm/renderer/actions/messages_test.cljs
@@ -18,4 +18,10 @@
       (is (= [[:effects/save [:topics "topic-1" :messages]
                [{:id 1 :type :user :text "Hello"}
                 {:id 2 :type :assistant :text "Hi there"}]]]
-             (msg/append-to-state state new-message))))))
+             (msg/append-to-state state new-message)))))
+  (testing "throws an error if no active topic is set"
+    (let [state {:topics {"topic-1" {:messages []}}
+                 :active-topic-id nil}
+          new-message {:id 1, :text "test"}]
+      (is (thrown-with-msg? js/Error #"Cannot append message: no active topic"
+            (msg/append-to-state state new-message))))))

--- a/test/gremllm/renderer/actions/messages_test.cljs
+++ b/test/gremllm/renderer/actions/messages_test.cljs
@@ -11,10 +11,11 @@
              {:type :assistant :text "Hi there"}])))))
 
 (deftest test-append-to-state
-  (testing "returns action to append message to topic messages"
-    (let [state {:topic {:messages [{:id 1 :type :user :text "Hello"}]}}
+  (testing "returns action to append message to the active topic's messages"
+    (let [state {:topics {"topic-1" {:messages [{:id 1 :type :user :text "Hello"}]}}
+                 :active-topic-id "topic-1"}
           new-message {:id 2 :type :assistant :text "Hi there"}]
-      (is (= [[:effects/save [:topic :messages] 
+      (is (= [[:effects/save [:topics "topic-1" :messages]
                [{:id 1 :type :user :text "Hello"}
                 {:id 2 :type :assistant :text "Hi there"}]]]
              (msg/append-to-state state new-message))))))

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -10,9 +10,10 @@
         expected-normalized-topic {:id "t1"
                                    :name "Test Topic"
                                    :messages [{:id "m1" :type :user :content "Hi"}]}]
-    (is (= [[:effects/save topic-state/topics-path expected-normalized-topic]]
+    (is (= [[:effects/save (conj topic-state/topics-path "t1") expected-normalized-topic]
+            [:effects/save topic-state/active-topic-id-path "t1"]]
            (topic/set-topic {} test-topic-js))
-        "should convert JS object, normalize it, and return a save effect"))
+        "should normalize the topic and save it to the topics map, and set it as active"))
 
   (is (nil? (topic/set-topic {} nil))
       "should return nil if input is nil"))
@@ -28,9 +29,10 @@
 
 (deftest start-new-topic-test
   (let [new-topic (topic/create-topic)]
-    (is (= [[:effects/save topic-state/topics-path new-topic]]
+    (is (= [[:effects/save (conj topic-state/topics-path (:id new-topic)) new-topic]
+            [:effects/save topic-state/active-topic-id-path (:id new-topic)]]
            (topic/start-new-topic {}))
-        "should return a save effect with a new topic structure")))
+        "should save a new topic and set it as active")))
 
 (deftest normalize-topic-test
   (let [denormalized {:id "t1"

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -47,14 +47,12 @@
       "should dispatch :start-new when topic is nil"))
 
 (deftest normalize-topic-test
-  (let [denormalized {:id "t1"
-                      :name "String Types"
-                      :messages [{:id "m1" :type "user"}
-                                 {:id "m2" :type "assistant"}]}
-        expected {:id "t1"
-                  :name "String Types"
-                  :messages [{:id "m1" :type :user}
-                             {:id "m2" :type :assistant}]}]
+  (let [denormalized (assoc expected-new-topic
+                            :messages [{:id "m1" :type "user"}
+                                       {:id "m2" :type "assistant"}])
+        expected     (assoc expected-new-topic
+                            :messages [{:id "m1" :type :user}
+                                       {:id "m2" :type :assistant}])]
     (is (= expected (topic/normalize-topic denormalized))
         "should convert message types from strings to keywords")))
 

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -10,7 +10,7 @@
         expected-normalized-topic {:id "t1"
                                    :name "Test Topic"
                                    :messages [{:id "m1" :type :user :content "Hi"}]}]
-    (is (= [[:effects/save topic-state/path expected-normalized-topic]]
+    (is (= [[:effects/save topic-state/topics-path expected-normalized-topic]]
            (topic/set-topic {} test-topic-js))
         "should convert JS object, normalize it, and return a save effect"))
 
@@ -28,7 +28,7 @@
 
 (deftest start-new-topic-test
   (let [new-topic (topic/create-topic)]
-    (is (= [[:effects/save topic-state/path new-topic]]
+    (is (= [[:effects/save topic-state/topics-path new-topic]]
            (topic/start-new-topic {}))
         "should return a save effect with a new topic structure")))
 

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -29,11 +29,12 @@
       "should dispatch :start-new when topic is nil"))
 
 (deftest start-new-topic-test
-  (let [new-topic (topic/create-topic)]
-    (is (= [[:effects/save (conj topic-state/topics-path (:id new-topic)) new-topic]
-            [:effects/save topic-state/active-topic-id-path (:id new-topic)]]
-           (topic/start-new-topic {}))
-        "should save a new topic and set it as active")))
+  (with-redefs [js/Date.now (constantly 12345)]
+    (let [expected-topic {:id "topic-12345" :name "New Topic" :messages []}]
+      (is (= [[:effects/save (conj topic-state/topics-path "topic-12345") expected-topic]
+              [:effects/save topic-state/active-topic-id-path "topic-12345"]]
+             (topic/start-new-topic {}))
+          "should save a new topic and set it as active"))))
 
 (deftest normalize-topic-test
   (let [denormalized {:id "t1"
@@ -48,11 +49,12 @@
         "should convert message types from strings to keywords")))
 
 (deftest create-topic-test
-  (is (= {:id "topic-1"
-          :name "New Topic"
-          :messages []}
-         (topic/create-topic))
-      "should create a topic with default values"))
+  (with-redefs [js/Date.now (constantly 54321)]
+    (is (= {:id "topic-54321"
+            :name "New Topic"
+            :messages []}
+           (topic/create-topic))
+        "should create a topic with a unique ID and default values")))
 
 (deftest bootstrap-test
   (is (= [[:system.actions/request-info]

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -24,9 +24,8 @@
 
 (deftest set-topic-test
   (testing "when a valid topic is provided"
-    (let [raw-topic {:id "t1"
-                     :name "Test Topic"
-                     :messages [{:id "m1" :type "user" :content "Hi"}]}
+    (let [raw-topic  (assoc expected-new-topic
+                            :messages [{:id "m1" :type "user" :content "Hi"}])
           test-topic-js (clj->js raw-topic)
           normalized-topic (topic/normalize-topic raw-topic)]
       (is (= [[:effects/save (conj topic-state/topics-path (:id raw-topic)) normalized-topic]
@@ -58,8 +57,6 @@
                              {:id "m2" :type :assistant}]}]
     (is (= expected (topic/normalize-topic denormalized))
         "should convert message types from strings to keywords")))
-
-
 
 (deftest bootstrap-test
   (is (= [[:system.actions/request-info]

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -61,3 +61,9 @@
           [:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
          (topic/bootstrap {}))
       "should request system info and then load the latest topic"))
+
+(deftest switch-topic-test
+  (testing "switching active topic"
+    (is (= [[:effects/save topic-state/active-topic-id-path "topic-2"]]
+           (topic/switch-topic {} "topic-2"))
+        "should dispatch an effect to update the active-topic-id")))

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -29,7 +29,7 @@
       "should dispatch :start-new when topic is nil"))
 
 (deftest start-new-topic-test
-  (with-redefs [js/Date.now (constantly 12345)]
+  (with-redefs [topic/get-timestamp (constantly 12345)]
     (let [expected-topic {:id "topic-12345" :name "New Topic" :messages []}]
       (is (= [[:effects/save (conj topic-state/topics-path "topic-12345") expected-topic]
               [:effects/save topic-state/active-topic-id-path "topic-12345"]]
@@ -49,7 +49,7 @@
         "should convert message types from strings to keywords")))
 
 (deftest create-topic-test
-  (with-redefs [js/Date.now (constantly 54321)]
+  (with-redefs [topic/get-timestamp (constantly 54321)]
     (is (= {:id "topic-54321"
             :name "New Topic"
             :messages []}

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -3,14 +3,14 @@
             [gremllm.renderer.actions.topic :as topic]
             [gremllm.renderer.state.topic :as topic-state]))
 
-(def ^:private test-timestamp 54321)
+(def ^:private test-topic-id (str "topic-" 54321))
 (def ^:private expected-new-topic
-  {:id (str "topic-" test-timestamp)
+  {:id   test-topic-id
    :name "New Topic"
    :messages []})
 
 (deftest create-topic-test
-  (with-redefs [topic/get-timestamp (constantly test-timestamp)]
+  (with-redefs [topic/generate-topic-id (constantly test-topic-id)]
     (is (= expected-new-topic
            (topic/create-topic))
         "should create a topic with a unique ID and default values")))


### PR DESCRIPTION
The app state now holds a map of topics keyed by a unique ID and an `active-topic-id` to reference the current conversation.