### PR TITLE
Refactor: Pass I/O paths as explicit function arguments

### DIFF
--- a/src/gremllm/main/actions.cljs
+++ b/src/gremllm/main/actions.cljs
@@ -3,7 +3,8 @@
             [gremllm.main.actions.ipc :as ipc-actions]
             [gremllm.main.actions.secrets :as secrets-actions]
             [gremllm.main.effects.llm :as llm-effects]
-            ["electron/main" :refer [BrowserWindow]]))
+            [gremllm.main.io :as io]
+            ["electron/main" :refer [BrowserWindow app]]))
 
 ;; Register how to extract state from the system
 (nxr/register-system->state! deref)
@@ -12,7 +13,9 @@
 (nxr/register-placeholder! :env/anthropic-api-key
   (fn [_]
     (or (.-ANTHROPIC_API_KEY (.-env js/process))
-        (some-> (secrets-actions/load nil nil :anthropic-api-key)
+        (some-> (.getPath app "userData")
+                (io/secrets-file-path)
+                (secrets-actions/load :anthropic-api-key)
                 :ok))))
 
 ;; Electron platform helpers (used by effects)

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -40,10 +40,10 @@
 
   ;; Topic handlers - call functions directly at the boundary
   (.handle ipcMain "topic/save"
-          (fn [_event topic-data]
-            (let [topic-clj (js->clj topic-data :keywordize-keys true)
-                  save-plan (topic-actions/prepare-save topic-clj topics-dir)]
-              (topic-effects/save save-plan))))
+           (fn [_event topic-data]
+             (-> (js->clj topic-data :keywordize-keys true)
+                 (topic-actions/prepare-save topics-dir)
+                 (topic-effects/save))))
 
   (.handle ipcMain "topic/load"
            (fn [_event]
@@ -60,10 +60,10 @@
 
   (.handle ipcMain "system/get-info"
            (fn [_event]
-             (let [secrets               (secrets/load-all secrets-filepath)
-                   encryption-available? (secrets/check-availability)]
-               (-> (system-info secrets encryption-available?)
-                   (clj->js))))))
+             (-> (system-info
+                   (secrets/load-all secrets-filepath)
+                   (secrets/check-availability))
+                 (clj->js)))))
 
 
 (defn main []

--- a/src/gremllm/main/io.cljs
+++ b/src/gremllm/main/io.cljs
@@ -35,3 +35,6 @@
   (let [dir-path (.dirname path filepath)]
     (ensure-dir dir-path)
     (write-file filepath (pr-str secrets-map))))
+
+(defn topics-dir-path [user-data-dir]
+  (.join path user-data-dir "topics"))

--- a/src/gremllm/main/io.cljs
+++ b/src/gremllm/main/io.cljs
@@ -32,9 +32,8 @@
     {}))
 
 (defn write-secrets-file [filepath secrets-map]
-  (let [dir-path (.dirname path filepath)]
-    (ensure-dir dir-path)
-    (write-file filepath (pr-str secrets-map))))
+  (ensure-dir (.dirname path filepath))
+  (write-file filepath (pr-str secrets-map)))
 
 (defn topics-dir-path [user-data-dir]
   (.join path user-data-dir "topics"))


### PR DESCRIPTION
Path generation is now centralized in `gremllm.main.core/main` at application startup, using helpers from `gremllm.main.io`.