### PR TITLE
Feat: deterministic bootstrap

### DIFF
--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -39,7 +39,7 @@ const createIPCBoundary = (channel) => {
 contextBridge.exposeInMainWorld("electronAPI", {
 	sendMessage: createIPCBoundary("chat/send-message"),
 	saveTopic: (topicData) => ipcRenderer.invoke("topic/save", topicData),
-	loadTopic: () => ipcRenderer.invoke("topic/load"),
+	loadLatestTopic: () => ipcRenderer.invoke("topic/load-latest"),
 	listTopics: () => ipcRenderer.invoke("topic/list"),
 	onMenuCommand: (command, callback) => ipcRenderer.on(command, callback),
 	getSystemInfo: () => ipcRenderer.invoke("system/get-info"),

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -44,9 +44,9 @@
                  (topic-actions/prepare-save topics-dir)
                  (topic-effects/save))))
 
-  (.handle ipcMain "topic/load"
+  (.handle ipcMain "topic/load-latest"
            (fn [_event]
-             (topic-effects/load topics-dir topic-actions/topic-file-pattern)))
+             (topic-effects/load-latest topics-dir topic-actions/topic-file-pattern)))
 
   (.handle ipcMain "topic/list"
            (fn [_event]

--- a/src/gremllm/main/effects/topic.cljs
+++ b/src/gremllm/main/effects/topic.cljs
@@ -10,14 +10,6 @@
   (io/write-file filepath content)
   filepath)
 
-(defn load-latest
-  "Loads the latest topic from the file system"
-  [topics-dir topic-file-pattern]
-  (when-let [filepath (io/find-latest-topic-file topics-dir topic-file-pattern)]
-    (-> (io/read-file filepath)
-        edn/read-string
-        (clj->js :keywordize-keys false))))
-
 (defn- file->topic-entry [topics-dir pattern filename]
   (when (re-matches pattern filename)
     {:filename filename
@@ -35,3 +27,12 @@
          (keep (partial file->topic-entry topics-dir topic-file-pattern))
          (sort-by :filename)
          vec)))
+
+(defn load-latest
+  "Loads the latest topic from the file system (reuses enumerate for DRY)."
+  [topics-dir topic-file-pattern]
+  ;; TODO: output of `enumerate` isn't sorted by last-accesssed, thus last is not latest
+  (when-let [{:keys [filepath]} (last (enumerate topics-dir topic-file-pattern))]
+    (-> (io/read-file filepath)
+        edn/read-string
+        (clj->js :keywordize-keys false))))

--- a/src/gremllm/main/effects/topic.cljs
+++ b/src/gremllm/main/effects/topic.cljs
@@ -12,8 +12,18 @@
 
 (defn- file->topic-entry [topics-dir pattern filename]
   (when (re-matches pattern filename)
-    {:filename filename
-     :filepath (io/path-join topics-dir filename)}))
+    (let [filepath      (io/path-join topics-dir filename)
+          stats         (io/file-stats filepath)
+          created-ms    (or (.-birthtimeMs stats)
+                            (.-ctimeMs stats)
+                            (some-> (.-birthtime stats) (.getTime))
+                            (some-> (.-ctime stats) (.getTime)))
+          accessed-ms   (or (.-atimeMs stats)
+                            (some-> (.-atime stats) (.getTime)))]
+      {:filename         filename
+       :filepath         filepath
+       :created-at       created-ms
+       :last-accessed-at accessed-ms})))
 
 (defn enumerate
   "Enumerate persisted topics for a workspace. Reads topics-dir and returns a vector of

--- a/src/gremllm/main/effects/topic.cljs
+++ b/src/gremllm/main/effects/topic.cljs
@@ -12,18 +12,10 @@
 
 (defn- file->topic-entry [topics-dir pattern filename]
   (when (re-matches pattern filename)
-    (let [filepath      (io/path-join topics-dir filename)
-          stats         (io/file-stats filepath)
-          created-ms    (or (.-birthtimeMs stats)
-                            (.-ctimeMs stats)
-                            (some-> (.-birthtime stats) (.getTime))
-                            (some-> (.-ctime stats) (.getTime)))
-          accessed-ms   (or (.-atimeMs stats)
-                            (some-> (.-atime stats) (.getTime)))]
-      {:filename         filename
-       :filepath         filepath
-       :created-at       created-ms
-       :last-accessed-at accessed-ms})))
+    (let [filepath (io/path-join topics-dir filename)]
+      (merge {:filename filename
+              :filepath filepath}
+             (io/file-timestamps filepath)))))
 
 (defn enumerate
   "Enumerate persisted topics for a workspace. Reads topics-dir and returns a vector of

--- a/src/gremllm/main/effects/topic.cljs
+++ b/src/gremllm/main/effects/topic.cljs
@@ -10,7 +10,7 @@
   (io/write-file filepath content)
   filepath)
 
-(defn load
+(defn load-latest
   "Loads the latest topic from the file system"
   [topics-dir topic-file-pattern]
   (when-let [filepath (io/find-latest-topic-file topics-dir topic-file-pattern)]

--- a/src/gremllm/main/io.cljs
+++ b/src/gremllm/main/io.cljs
@@ -48,13 +48,6 @@
   [dir]
   (array-seq (.readdirSync fs dir)))
 
-(defn find-latest-topic-file [dir file-pattern]
-  (when (file-exists? dir)
-    (when-let [latest-file (->> (read-dir dir)
-                                (filter #(re-matches file-pattern %))
-                                sort
-                                last)]
-      (path-join dir latest-file))))
 
 (defn delete-file
   "Delete a file at filepath."

--- a/src/gremllm/main/io.cljs
+++ b/src/gremllm/main/io.cljs
@@ -43,10 +43,23 @@
   [p]
   (.existsSync fs p))
 
-(defn file-stats
+(defn- file-stats
   "Return Node.js fs.Stats for the given filepath."
   [filepath]
   (.statSync fs filepath))
+
+(defn file-timestamps
+  "Return a map of file timestamp metadata (in ms since epoch)."
+  [filepath]
+  (let [stats (file-stats filepath)
+        created-ms  (or (.-birthtimeMs stats)
+                        (.-ctimeMs stats)
+                        (some-> (.-birthtime stats) (.getTime))
+                        (some-> (.-ctime stats) (.getTime)))
+        accessed-ms (or (.-atimeMs stats)
+                        (some-> (.-atime stats) (.getTime)))]
+    {:created-at       created-ms
+     :last-accessed-at accessed-ms}))
 
 (defn read-dir
   "Return a seq of entries in dir."

--- a/src/gremllm/main/io.cljs
+++ b/src/gremllm/main/io.cljs
@@ -43,6 +43,11 @@
   [p]
   (.existsSync fs p))
 
+(defn file-stats
+  "Return Node.js fs.Stats for the given filepath."
+  [filepath]
+  (.statSync fs filepath))
+
 (defn read-dir
   "Return a seq of entries in dir."
   [dir]

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -62,6 +62,8 @@
 ;; Register all topic actions
 (nxr/register-action! :topic.actions/set topic/set-topic)
 (nxr/register-action! :topic.actions/bootstrap topic/bootstrap)
+(nxr/register-action! :topic.actions/determine-initial-topic topic/determine-initial-topic)
+(nxr/register-action! :topic.actions/list-topics-error topic/list-topics-error)
 (nxr/register-action! :topic.actions/restore-or-create-topic topic/restore-or-create-topic)
 (nxr/register-action! :topic.actions/start-new topic/start-new-topic)
 (nxr/register-action! :topic.actions/switch-to topic/switch-topic)

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -35,20 +35,20 @@
     [[:topic.actions/set loaded-topic]]
     [[:topic.actions/start-new]]))
 
-(defn handle-list [_state topics-js]
+(defn determine-initial-topic [_state topics-js]
   (let [entries (js->clj topics-js :keywordize-keys true)]
     (if (seq entries)
       [[:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
       [[:topic.actions/start-new]])))
 
-(defn list-error [_state error]
+(defn list-topics-error [_state error]
   (js/console.error "list-topics failed:" error)
   [[:topic.actions/start-new]])
 
 (defn bootstrap [_state]
   [[:system.actions/request-info]
-   [:topic.effects/list {:on-success [:topic.actions/handle-list]
-                         :on-error   [:topic.actions/list-error]}]])
+   [:topic.effects/list {:on-success [:topic.actions/determine-initial-topic]
+                         :on-error   [:topic.actions/list-topics-error]}]])
 
 (defn start-new-topic [_state]
   (let [new-topic (create-topic)]
@@ -82,8 +82,8 @@
 
 (nxr/register-effect! :topic.effects/list
   (fn [{dispatch :dispatch} _store & [opts]]
-    (let [on-success (or (:on-success opts) [:topic.actions/handle-list])
-          on-error   (or (:on-error opts)   [:topic.actions/list-error])]
+    (let [on-success (or (:on-success opts) [:topic.actions/determine-initial-topic])
+          on-error   (or (:on-error opts)   [:topic.actions/list-topics-error])]
       (dispatch
         [[:effects/promise
           {:promise    (.listTopics js/window.electronAPI)

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -38,7 +38,7 @@
 (defn determine-initial-topic [_state topics-js]
   (let [entries (js->clj topics-js :keywordize-keys true)]
     (if (seq entries)
-      [[:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
+      [[:topic.effects/load-latest-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
       [[:topic.actions/start-new]])))
 
 (defn list-topics-error [_state error]
@@ -71,12 +71,12 @@
   [[:effects/save topic-state/active-topic-id-path topic-id]])
 
 ;; Effects for topic persistence
-(nxr/register-effect! :topic.effects/load-topic
+(nxr/register-effect! :topic.effects/load-latest-topic
   (fn [{dispatch :dispatch} _store & [opts]]
     (let [on-success (or (:on-success opts) [:topic.actions/set])]
       (dispatch
         [[:effects/promise
-          {:promise    (.loadTopic js/window.electronAPI)
+          {:promise    (.loadLatestTopic js/window.electronAPI)
            :on-success on-success
            :on-error   [:topic.actions/load-topic-error]}]]))))
 

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -12,9 +12,10 @@
                     (fn []
                       (nxr/dispatch store {} [[:topic.effects/save-active-topic]])))
 
+    ;; TODO: remove. Menu should open a workspace, not topic
     (.onMenuCommand js/window.electronAPI "topic/open"
                     (fn []
-                      (nxr/dispatch store {} [[:topic.effects/load-topic]])))
+                      (nxr/dispatch store {} [[:topic.effects/load-latest-topic]])))
 
     (.onMenuCommand js/window.electronAPI "menu:settings"
                     (fn []

--- a/test/gremllm/main/effects/topic_test.cljs
+++ b/test/gremllm/main/effects/topic_test.cljs
@@ -29,7 +29,7 @@
                                        :filepath filepath
                                        :content (pr-str topic)})
 
-              loaded-js (topic/load temp-dir #"topic-\d+\.edn")
+              loaded-js (topic/load-latest temp-dir #"topic-\d+\.edn")
               loaded    (js->clj loaded-js :keywordize-keys true)]
           (is (= topic loaded)))
 

--- a/test/gremllm/main/effects/topic_test.cljs
+++ b/test/gremllm/main/effects/topic_test.cljs
@@ -49,8 +49,11 @@
         (let [files-to-create ["topic-200.edn" "notes.txt" "topic-100.edn"]
               _               (doseq [f files-to-create]
                                 (io/write-file (io/path-join dir f) "{}"))]
-          (is (= [{:filename "topic-100.edn"
-                   :filepath (io/path-join dir "topic-100.edn")}
-                  {:filename "topic-200.edn"
-                   :filepath (io/path-join dir "topic-200.edn")}]
-                 (topic/enumerate dir #"topic-\d+\.edn"))))))))
+          (let [entries (topic/enumerate dir #"topic-\d+\.edn")]
+            (is (= [{:filename "topic-100.edn"
+                     :filepath (io/path-join dir "topic-100.edn")}
+                    {:filename "topic-200.edn"
+                     :filepath (io/path-join dir "topic-200.edn")}]
+                   (mapv #(select-keys % [:filename :filepath]) entries)))
+            (is (every? number? (map :created-at entries)))
+            (is (every? number? (map :last-accessed-at entries)))))))))

--- a/test/gremllm/main/io_test.cljs
+++ b/test/gremllm/main/io_test.cljs
@@ -3,6 +3,7 @@
             [clojure.string]
             [gremllm.main.io :as io]))
 
+;; TODO: refactor for DRY: with-temp-dir is duplicated in gremllm.main.effects.topic-test
 (defn- with-temp-dir [suffix f]
   (let [os  (js/require "os")
         dir (io/path-join (.tmpdir os) (str "gremllm-test-" (.getTime (js/Date.)) "-" suffix))]

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -58,9 +58,18 @@
 
 (deftest bootstrap-test
   (is (= [[:system.actions/request-info]
-          [:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
+          [:topic.effects/list {:on-success [:topic.actions/handle-list]
+                                :on-error   [:topic.actions/list-error]}]]
          (topic/bootstrap {}))
-      "should request system info and then load the latest topic"))
+      "should request system info and then list topics to decide newest-or-create"))
+
+(deftest handle-list-test
+  (testing "when topics exist"
+    (is (= [[:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
+           (topic/handle-list {} (clj->js [{:filename "topic-1.edn" :filepath "/tmp/topic-1.edn"}])))))
+  (testing "when no topics exist"
+    (is (= [[:topic.actions/start-new]]
+           (topic/handle-list {} (clj->js []))))))
 
 (deftest switch-topic-test
   (testing "switching active topic"

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -65,7 +65,7 @@
 
 (deftest determine-initial-topic-test
   (testing "when topics exist"
-    (is (= [[:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
+    (is (= [[:topic.effects/load-latest-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
            (topic/determine-initial-topic {} (clj->js [{:filename "topic-1.edn" :filepath "/tmp/topic-1.edn"}])))))
   (testing "when no topics exist"
     (is (= [[:topic.actions/start-new]]

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -58,18 +58,18 @@
 
 (deftest bootstrap-test
   (is (= [[:system.actions/request-info]
-          [:topic.effects/list {:on-success [:topic.actions/handle-list]
-                                :on-error   [:topic.actions/list-error]}]]
+          [:topic.effects/list {:on-success [:topic.actions/determine-initial-topic]
+                                :on-error   [:topic.actions/list-topics-error]}]]
          (topic/bootstrap {}))
       "should request system info and then list topics to decide newest-or-create"))
 
-(deftest handle-list-test
+(deftest determine-initial-topic-test
   (testing "when topics exist"
     (is (= [[:topic.effects/load-topic {:on-success [:topic.actions/restore-or-create-topic]}]]
-           (topic/handle-list {} (clj->js [{:filename "topic-1.edn" :filepath "/tmp/topic-1.edn"}])))))
+           (topic/determine-initial-topic {} (clj->js [{:filename "topic-1.edn" :filepath "/tmp/topic-1.edn"}])))))
   (testing "when no topics exist"
     (is (= [[:topic.actions/start-new]]
-           (topic/handle-list {} (clj->js []))))))
+           (topic/determine-initial-topic {} (clj->js []))))))
 
 (deftest switch-topic-test
   (testing "switching active topic"


### PR DESCRIPTION
Introduces a new `topic/list` method that enumerates all persisted topics along with their timestamp metadata. The initial application bootstrap now utilizes this enumeration to determine whether to load an existing topic or create a new one.