### PR TITLE
refactor: render model selector inside form

### DIFF
--- a/src/gremllm/renderer/actions/ui.cljs
+++ b/src/gremllm/renderer/actions/ui.cljs
@@ -23,11 +23,13 @@
     (swap! store assoc-in form-state/selected-model-path value)))
 
 (defn submit-messages [state]
-  (let [text (form-state/get-user-input state)]
+  (let [text (form-state/get-user-input state)
+        model (form-state/get-selected-model state)]
     (when-not (empty? text)
       ;; TODO: IDs should use UUID, but need to ensure clj->js->clj through IPC works properly.
       ;; Probably with Malli.
       (let [assistant-id (.now js/Date)]
+        (js/console.log "Submitting with model:" model) ;; TODO: make use of selected model
         [[:messages.actions/add-to-chat {:id   (.now js/Date)
                                          :type :user
                                          :text text}]

--- a/src/gremllm/renderer/ui/chat.cljs
+++ b/src/gremllm/renderer/ui/chat.cljs
@@ -58,9 +58,9 @@
 
 (defn render-input-form [{:keys [input-value selected-model has-messages? loading? has-api-key?]}]
   [:footer
-   (render-model-selector selected-model has-messages?)
    [:form {:on {:submit [[:effects/prevent-default]
                          [:form.actions/submit]]}}
+    (render-model-selector selected-model has-messages?)
     [:fieldset {:role "group"}
      [:input {:type "text"
               :value input-value


### PR DESCRIPTION
## WIP: Model Selection - Paused for Auto-Save Dependency

  **Current state:** Model selection UI complete, model stored in topic state, ready to wire through to Main.

  **Why paused:** Need auto-save first. Once auto-save is implemented, Main will already have model data from topic saves. We can then use topic-scoped
  cache in Main (lookup by topic-id) instead of sending model with every LLM request.

  **Next steps after auto-save:**
  1. Main: Cache `{topic-id → model}` from auto-save events
  2. Renderer: Send topic-id with LLM requests
  3. Main: Lookup model by topic-id for LLM calls