### PR TITLE
Feat: Propagate selected model from UI through IPC to LLM

### DIFF
--- a/src/gremllm/main/actions.cljs
+++ b/src/gremllm/main/actions.cljs
@@ -65,8 +65,8 @@
 
 ;; LLM effects
 (nxr/register-effect! :chat.effects/send-message
-  (fn [{:keys [dispatch]} _ messages api-key]
-    (dispatch [[:ipc.effects/promise->reply (llm-effects/query-llm-provider messages api-key)]])))
+  (fn [{:keys [dispatch]} _ messages model api-key]
+    (dispatch [[:ipc.effects/promise->reply (llm-effects/query-llm-provider messages model api-key)]])))
 
 ;; Workspace Actions/Effects Registration
 (nxr/register-action! :workspace.actions/set-directory workspace-actions/set-directory)

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -34,12 +34,12 @@
             Secrets (config), System (capabilities)"
   [store secrets-filepath]
   (.on ipcMain "chat/send-message"
-       (fn [event request-id messages]
+       (fn [event request-id messages model]
          (let [messages-clj (js->clj messages :keywordize-keys true)]
            (nxr/dispatch store {:ipc-event event
                                 :request-id request-id
                                 :channel "chat/send-message"}
-                         [[:chat.effects/send-message messages-clj [:env/anthropic-api-key]]]))))
+                         [[:chat.effects/send-message messages-clj model [:env/anthropic-api-key]]]))))
 
   (.handle ipcMain "topic/save"
            (fn [_event topic-data]

--- a/src/gremllm/main/effects/llm.cljs
+++ b/src/gremllm/main/effects/llm.cljs
@@ -3,8 +3,8 @@
 
 (defn query-llm-provider
   "Performs HTTP request to Anthropic API"
-  [messages api-key]
-  (let [request-body {:model "claude-3-5-haiku-latest"
+  [messages model api-key]
+  (let [request-body {:model model
                       :max_tokens 8192
                       :messages messages}
         headers {"x-api-key" api-key

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -85,7 +85,6 @@
 ;; Topic
 
 ;; Register all topic actions
-(nxr/register-action! :topic.actions/set topic/set-topic)
 (nxr/register-action! :topic.actions/start-new topic/start-new-topic)
 (nxr/register-action! :topic.actions/switch-to topic/switch-topic)
 (nxr/register-action! :topic.actions/begin-rename topic/begin-rename)

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -6,7 +6,8 @@
             [gremllm.renderer.actions.workspace :as workspace]
             [gremllm.renderer.actions.system :as system]
             [gremllm.renderer.actions.settings :as settings]
-            [gremllm.renderer.state.ui :as ui-state]))
+            [gremllm.renderer.state.ui :as ui-state]
+            [gremllm.renderer.state.topic :as topic-state]))
 
 ;; Set up how to extract state from your atom
 (nxr/register-system->state! deref)
@@ -87,6 +88,9 @@
 ;; Register all topic actions
 (nxr/register-action! :topic.actions/start-new topic/start-new-topic)
 (nxr/register-action! :topic.actions/switch-to topic/switch-topic)
+(nxr/register-action! :topic.actions/set-active
+  (fn [_state topic-id]
+    [[:effects/save topic-state/active-topic-id-path topic-id]]))
 (nxr/register-action! :topic.actions/begin-rename topic/begin-rename)
 (nxr/register-action! :topic.actions/commit-rename topic/commit-rename)
 (nxr/register-action! :topic.actions/set-name topic/set-name)

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -88,9 +88,7 @@
 ;; Register all topic actions
 (nxr/register-action! :topic.actions/start-new topic/start-new-topic)
 (nxr/register-action! :topic.actions/switch-to topic/switch-topic)
-(nxr/register-action! :topic.actions/set-active
-  (fn [_state topic-id]
-    [[:effects/save topic-state/active-topic-id-path topic-id]]))
+(nxr/register-action! :topic.actions/set-active topic/set-active)
 (nxr/register-action! :topic.actions/begin-rename topic/begin-rename)
 (nxr/register-action! :topic.actions/commit-rename topic/commit-rename)
 (nxr/register-action! :topic.actions/set-name topic/set-name)

--- a/src/gremllm/renderer/actions/messages.cljs
+++ b/src/gremllm/renderer/actions/messages.cljs
@@ -53,13 +53,13 @@
 
 ;; Effect for sending messages to LLM
 (nxr/register-effect! :llm.effects/send-llm-messages
-  (fn [{dispatch :dispatch} store assistant-id]
+  (fn [{dispatch :dispatch} store assistant-id model]
     (dispatch
       [[:effects/promise
         {:promise    (-> (topic-state/get-messages @store)
                          (messages->api-format)
                          (clj->js)
-                         (js/window.electronAPI.sendMessage))
+                         (js/window.electronAPI.sendMessage model))
          :on-success [[:llm.actions/response-received assistant-id]]
          :on-error   [[:llm.actions/response-error assistant-id]]}]])))
 

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -5,13 +5,6 @@
             [gremllm.renderer.state.ui :as ui-state]
             [gremllm.schema :as schema]))
 
-(defn set-topic [_state topic-js]
-  (when topic-js
-    (let [topic (schema/topic-from-ipc topic-js)
-          topic-id (:id topic)]
-      [[:effects/save (topic-state/topic-path topic-id) topic]
-       [:effects/save topic-state/active-topic-id-path topic-id]])))
-
 (defn start-new-topic [_state]
   (let [new-topic (schema/create-topic)]
     [[:effects/save (topic-state/topic-path (:id new-topic)) new-topic]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -41,9 +41,13 @@
              (seq))
      [[:topic.effects/save-topic topic-id]])))
 
-(defn set-active [state topic-id]
-  [[:effects/save topic-state/active-topic-id-path topic-id]
-   [:form.effects/update-model (topic-state/get-topic-field state topic-id :model)]])
+(defn set-active
+  "Set the active topic. Optionally accepts model to avoid reading from state."
+  ([state topic-id]
+   (set-active state topic-id (topic-state/get-topic-field state topic-id :model)))
+  ([_state topic-id model]
+   [[:effects/save topic-state/active-topic-id-path topic-id]
+    [:form.effects/update-model model]]))
 
 ;; TODO: we can probably remove this and use set-active directly
 (defn switch-topic [_state topic-id]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -8,7 +8,7 @@
 (defn start-new-topic [_state]
   (let [new-topic (schema/create-topic)]
     [[:effects/save (topic-state/topic-path (:id new-topic)) new-topic]
-     [:effects/save topic-state/active-topic-id-path (:id new-topic)]]))
+     [:topic.actions/set-active (:id new-topic)]]))
 
 (defn mark-saved [_state topic-id]
   [[:effects/save (topic-state/topic-field-path topic-id :unsaved?) false]])
@@ -43,7 +43,7 @@
 
 (defn switch-topic [_state topic-id]
   ;; TODO: :form.effects/update-model with active topic model
-  [[:effects/save topic-state/active-topic-id-path topic-id]])
+  [[:topic.actions/set-active topic-id]])
 
 (defn begin-rename [state topic-id]
   ;; Enter inline rename mode for this topic

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -49,6 +49,7 @@
      [[:topic.effects/save-topic topic-id]])))
 
 (defn switch-topic [_state topic-id]
+  ;; TODO: :form.effects/update-model with active topic model
   [[:effects/save topic-state/active-topic-id-path topic-id]])
 
 (defn begin-rename [state topic-id]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -8,7 +8,8 @@
 (defn start-new-topic [_state]
   (let [new-topic (schema/create-topic)]
     [[:effects/save (topic-state/topic-path (:id new-topic)) new-topic]
-     [:topic.actions/set-active (:id new-topic)]]))
+     ;; TODO: pass a default model instead of nil
+     [:topic.actions/set-active (:id new-topic) nil]]))
 
 (defn mark-saved [_state topic-id]
   [[:effects/save (topic-state/topic-field-path topic-id :unsaved?) false]])

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -6,10 +6,11 @@
             [gremllm.schema :as schema]))
 
 (defn start-new-topic [_state]
-  (let [new-topic (schema/create-topic)]
-    [[:effects/save (topic-state/topic-path (:id new-topic)) new-topic]
-     ;; TODO: pass a default model instead of nil
-     [:topic.actions/set-active (:id new-topic) nil]]))
+  (let [new-topic     (schema/create-topic)
+        topic-id      (:id new-topic)
+        default-model (:model new-topic)]
+    [[:effects/save (topic-state/topic-path topic-id) new-topic]
+     [:topic.actions/set-active topic-id default-model]]))
 
 (defn mark-saved [_state topic-id]
   [[:effects/save (topic-state/topic-field-path topic-id :unsaved?) false]])

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -41,9 +41,9 @@
              (seq))
      [[:topic.effects/save-topic topic-id]])))
 
-(defn switch-topic [_state topic-id]
-  ;; TODO: :form.effects/update-model with active topic model
-  [[:topic.actions/set-active topic-id]])
+(defn switch-topic [state topic-id]
+  [[:topic.actions/set-active topic-id]
+   [:form.effects/update-model (topic-state/get-topic-field state topic-id :model)]])
 
 (defn begin-rename [state topic-id]
   ;; Enter inline rename mode for this topic

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -45,7 +45,8 @@
   [[:effects/save topic-state/active-topic-id-path topic-id]
    [:form.effects/update-model (topic-state/get-topic-field state topic-id :model)]])
 
-(defn switch-topic [state topic-id]
+;; TODO: we can probably remove this and use set-active directly
+(defn switch-topic [_state topic-id]
   [[:topic.actions/set-active topic-id]])
 
 (defn begin-rename [state topic-id]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -41,9 +41,12 @@
              (seq))
      [[:topic.effects/save-topic topic-id]])))
 
-(defn switch-topic [state topic-id]
-  [[:topic.actions/set-active topic-id]
+(defn set-active [state topic-id]
+  [[:effects/save topic-state/active-topic-id-path topic-id]
    [:form.effects/update-model (topic-state/get-topic-field state topic-id :model)]])
+
+(defn switch-topic [state topic-id]
+  [[:topic.actions/set-active topic-id]])
 
 (defn begin-rename [state topic-id]
   ;; Enter inline rename mode for this topic

--- a/src/gremllm/renderer/actions/ui.cljs
+++ b/src/gremllm/renderer/actions/ui.cljs
@@ -29,7 +29,6 @@
       ;; TODO: IDs should use UUID, but need to ensure clj->js->clj through IPC works properly.
       ;; Probably with Malli.
       (let [assistant-id (.now js/Date)]
-        (js/console.log "Submitting with model:" model) ;; TODO: make use of selected model
         [[:messages.actions/add-to-chat {:id   (.now js/Date)
                                          :type :user
                                          :text text}]
@@ -37,7 +36,7 @@
          [:loading.effects/set-loading? assistant-id true]
          [:llm.effects/unset-all-errors]
          [:effects/scroll-to-bottom "chat-messages-container"]
-         [:llm.effects/send-llm-messages assistant-id]]))))
+         [:llm.effects/send-llm-messages assistant-id model]]))))
 
 ;; Scroll to bottom effect for chat area
 (nxr/register-effect! :effects/scroll-to-bottom

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -35,10 +35,9 @@
 
 (defn restore-with-topics
   "Restore a workspace that has existing topics."
-  [state {:keys [topics active-topic-id]}]
+  [_state {:keys [topics active-topic-id]}]
   [[:effects/save topic-state/topics-path topics]
    [:topic.actions/set-active active-topic-id]
-   [:form.effects/update-model (topic-state/get-topic-field state active-topic-id :model)]
    [:workspace.actions/mark-loaded]])
 
 (defn initialize-empty

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -38,6 +38,7 @@
   [_state {:keys [topics active-topic-id]}]
   [[:effects/save topic-state/topics-path topics]
    [:effects/save topic-state/active-topic-id-path active-topic-id]
+   ;; TODO: :form.effects/update-model with active topic model
    [:workspace.actions/mark-loaded]])
 
 (defn initialize-empty

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -37,7 +37,7 @@
   "Restore a workspace that has existing topics."
   [_state {:keys [topics active-topic-id]}]
   [[:effects/save topic-state/topics-path topics]
-   [:topic.actions/set-active active-topic-id]
+   [:topic.actions/set-active active-topic-id (get-in topics [active-topic-id :model])]
    [:workspace.actions/mark-loaded]])
 
 (defn initialize-empty

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -36,9 +36,11 @@
 (defn restore-with-topics
   "Restore a workspace that has existing topics."
   [_state {:keys [topics active-topic-id]}]
-  [[:effects/save topic-state/topics-path topics]
-   [:topic.actions/set-active active-topic-id (get-in topics [active-topic-id :model])]
-   [:workspace.actions/mark-loaded]])
+  (let [active-topic (get topics active-topic-id)
+        model        (:model active-topic)]
+    [[:effects/save topic-state/topics-path topics]
+     [:topic.actions/set-active active-topic-id model]
+     [:workspace.actions/mark-loaded]]))
 
 (defn initialize-empty
   "Initialize an empty workspace with its first topic."

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -37,7 +37,7 @@
   "Restore a workspace that has existing topics."
   [_state {:keys [topics active-topic-id]}]
   [[:effects/save topic-state/topics-path topics]
-   [:effects/save topic-state/active-topic-id-path active-topic-id]
+   [:topic.actions/set-active active-topic-id]
    ;; TODO: :form.effects/update-model with active topic model
    [:workspace.actions/mark-loaded]])
 

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -35,10 +35,10 @@
 
 (defn restore-with-topics
   "Restore a workspace that has existing topics."
-  [_state {:keys [topics active-topic-id]}]
+  [state {:keys [topics active-topic-id]}]
   [[:effects/save topic-state/topics-path topics]
    [:topic.actions/set-active active-topic-id]
-   ;; TODO: :form.effects/update-model with active topic model
+   [:form.effects/update-model (topic-state/get-topic-field state active-topic-id :model)]
    [:workspace.actions/mark-loaded]])
 
 (defn initialize-empty

--- a/test/gremllm/main/effects/llm_test.cljs
+++ b/test/gremllm/main/effects/llm_test.cljs
@@ -26,6 +26,7 @@
   (testing "successfully parses Claude API response"
     (let [original-fetch       js/fetch
           test-messages        [{:role "user" :content "2+2"}]
+          test-model           "claude-3-5-haiku-latest"
           test-api-key         "test-key"
           mock-claude-response {:id "msg_01LaTD7HNzYujxh6ASPpTQ6T"
                                 :type "message"
@@ -42,7 +43,7 @@
 
       (set! js/fetch (mock-successful-fetch mock-claude-response))
 
-      (-> (llm/query-llm-provider test-messages test-api-key)
+      (-> (llm/query-llm-provider test-messages test-model test-api-key)
           (.then (fn [response]
                    (testing "response structure"
                      (is (= (:id response) "msg_01LaTD7HNzYujxh6ASPpTQ6T"))
@@ -60,12 +61,13 @@
   (testing "API errors are propagated as rejected promises"
     (let [original-fetch js/fetch
           test-messages [{:role "user" :content "Hello"}]
+          test-model "claude-3-5-haiku-latest"
           test-api-key "test-key"
           error-message "Network error"]
 
       (set! js/fetch (mock-failed-fetch error-message))
 
-      (-> (llm/query-llm-provider test-messages test-api-key)
+      (-> (llm/query-llm-provider test-messages test-model test-api-key)
           (.then (fn [_]
                    (is false "Should not succeed")))
           (.catch (fn [error]

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -7,15 +7,15 @@
 
 (deftest start-new-topic-test
   (let [result (topic/start-new-topic {})
-        [[_ topic-path saved-topic] [_ active-path active-id]] result]
+        [[_ topic-path saved-topic] [action-name active-id]] result]
 
     (is (= 2 (count result)) "should return exactly two effects")
-    (is (every? #(= :effects/save (first %)) result) "both should be save effects")
 
+    (is (= :effects/save (first (first result))) "first should be save effect")
     (is (m/validate schema/Topic saved-topic) "saved topic should be valid per schema")
     (is (= (topic-state/topic-path (:id saved-topic)) topic-path) "should save to correct topics path")
 
-    (is (= topic-state/active-topic-id-path active-path) "should save to active topic path")
+    (is (= :topic.actions/set-active action-name) "second should be set-active action")
     (is (= (:id saved-topic) active-id) "should set same topic ID as active")))
 
 (def ^:private expected-new-topic (schema/create-topic))
@@ -32,6 +32,6 @@
 
 (deftest switch-topic-test
   (testing "switching active topic"
-    (is (= [[:effects/save topic-state/active-topic-id-path "topic-2"]]
+    (is (= [[:topic.actions/set-active "topic-2"]]
            (topic/switch-topic {} "topic-2"))
-        "should dispatch an effect to update the active-topic-id")))
+        "should dispatch set-active action")))

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -32,6 +32,8 @@
 
 (deftest switch-topic-test
   (testing "switching active topic"
-    (is (= [[:topic.actions/set-active "topic-2"]]
-           (topic/switch-topic {} "topic-2"))
-        "should dispatch set-active action")))
+    (let [state {:topics {"topic-2" {:id "topic-2" :model "anthropic/claude-sonnet-4-5"}}}]
+      (is (= [[:topic.actions/set-active "topic-2"]
+              [:form.effects/update-model "anthropic/claude-sonnet-4-5"]]
+             (topic/switch-topic state "topic-2"))
+          "should dispatch set-active and update-model actions"))))

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -20,21 +20,6 @@
 
 (def ^:private expected-new-topic (schema/create-topic))
 
-(deftest set-topic-test
-  (testing "when a valid topic is provided"
-    (let [raw-topic  (assoc expected-new-topic
-                            :messages [{:id "m1" :type "user" :content "Hi"}])
-          test-topic-js (clj->js raw-topic)
-          normalized-topic (schema/topic-from-ipc raw-topic)]
-      (is (= [[:effects/save (topic-state/topic-path (:id raw-topic)) normalized-topic]
-              [:effects/save topic-state/active-topic-id-path (:id raw-topic)]]
-             (topic/set-topic {} test-topic-js))
-          "should normalize the topic, save it to the topics map, and set it as active")))
-
-  (testing "when input is nil"
-    (is (nil? (topic/set-topic {} nil))
-        "should return nil")))
-
 (deftest normalize-topic-test
   (let [denormalized (assoc expected-new-topic
                             :messages [{:id "m1" :type "user"}

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -32,8 +32,6 @@
 
 (deftest switch-topic-test
   (testing "switching active topic"
-    (let [state {:topics {"topic-2" {:id "topic-2" :model "anthropic/claude-sonnet-4-5"}}}]
-      (is (= [[:topic.actions/set-active "topic-2"]
-              [:form.effects/update-model "anthropic/claude-sonnet-4-5"]]
-             (topic/switch-topic state "topic-2"))
-          "should dispatch set-active and update-model actions"))))
+    (is (= [[:topic.actions/set-active "topic-2"]]
+           (topic/switch-topic {} "topic-2"))
+        "should dispatch set-active action")))

--- a/test/gremllm/renderer/actions/ui_test.cljs
+++ b/test/gremllm/renderer/actions/ui_test.cljs
@@ -4,10 +4,12 @@
 
 (deftest test-submit-message
   (testing "does nothing with empty input"
-    (is (nil? (ui/submit-messages {:form {:user-input ""}}))))
+    (is (nil? (ui/submit-messages {:form {:user-input ""
+                                          :selected-model "claude-3-5-haiku-latest"}}))))
 
   (testing "submits message with valid input"
-    (let [effects (ui/submit-messages {:form {:user-input "Hello"}})]
+    (let [effects (ui/submit-messages {:form {:user-input "Hello"
+                                              :selected-model "claude-3-5-haiku-latest"}})]
       (is (= 6 (count effects)))
       (is (= :messages.actions/add-to-chat (ffirst effects)))
       (is (= :form.effects/clear-input (first (second effects))))


### PR DESCRIPTION
Pass the selected model from the renderer UI through the renderer effects and IPC to the main LLM request path. query-llm-provider now accepts (messages, model, api-key) and uses model in the request body; ipcMain "chat/send-message", chat.effects/send-message, llm.effects/send-llm-messages, UI submit flow, topic actions (added topic.actions/set-active, removed set-topic), workspace restore, and related tests were updated to forward and use the model.