### PR TITLE
Tests: Add tests for LLM responses, topic rename/auto-save, and workspace/UI

### DIFF
--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -1,7 +1,8 @@
 (ns gremllm.renderer.actions.topic-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is testing]]
             [gremllm.renderer.actions.topic :as topic]
             [gremllm.renderer.state.topic :as topic-state]
+            [gremllm.renderer.state.ui :as ui-state]
             [gremllm.schema :as schema]
             [malli.core :as m]))
 
@@ -29,4 +30,41 @@
                                        {:id "m2" :type :assistant}])]
     (is (= expected (schema/topic-from-ipc denormalized))
         "should convert message types from strings to keywords")))
+
+(deftest commit-rename-test
+  (let [topic-id "topic-123"
+        state    {:topics {topic-id {:id topic-id :name "Original Name"}}}]
+
+    (testing "blank name - should exit rename mode without saving"
+      (let [actions (topic/commit-rename state topic-id "   ")]
+        (is (= 1 (count actions)))
+        (is (= :ui.actions/exit-topic-rename-mode (ffirst actions)))))
+
+    (testing "unchanged name - should exit rename mode without saving"
+      (let [actions (topic/commit-rename state topic-id "Original Name")]
+        (is (= 1 (count actions)))
+        (is (= :ui.actions/exit-topic-rename-mode (ffirst actions)))))
+
+    (testing "valid new name - should save, exit rename mode, and auto-save"
+      (let [actions (topic/commit-rename state topic-id "New Name")]
+        (is (= 3 (count actions)))
+        (is (= :topic.actions/set-name (ffirst actions)))
+        (is (= "New Name" (nth (first actions) 2)))
+        (is (= :ui.actions/exit-topic-rename-mode (first (second actions))))
+        (is (= :topic.actions/auto-save (first (nth actions 2))))))))
+
+(deftest auto-save-test
+  (let [topic-id       "topic-123"
+        empty-topic    {:id topic-id :messages []}
+        topic-with-msg {:id topic-id :messages [{:id "m1" :type :user :content "hi"}]}]
+
+    (testing "should not trigger save when topic has no messages"
+      (let [state  {:topics {topic-id empty-topic}}
+            actions (topic/auto-save state topic-id)]
+        (is (nil? actions))))
+
+    (testing "should trigger save when topic has messages"
+      (let [state  {:topics {topic-id topic-with-msg}}
+            actions (topic/auto-save state topic-id)]
+        (is (= [[:topic.effects/save-topic topic-id]] actions))))))
 

--- a/test/gremllm/renderer/actions/workspace_test.cljs
+++ b/test/gremllm/renderer/actions/workspace_test.cljs
@@ -69,6 +69,9 @@
 
 (deftest load-error-test
   (testing "Returns no effects on error"
-    (let [effects (workspace/load-error {} (js/Error. "Test error"))]
+    (let [original-error js/console.error
+          _              (set! js/console.error (fn [& _args]))  ; Suppress error logging
+          effects        (workspace/load-error {} (js/Error. "Test error"))]
+      (set! js/console.error original-error)  ; Restore
       (is (empty? effects)))))
 

--- a/test/gremllm/renderer/actions/workspace_test.cljs
+++ b/test/gremllm/renderer/actions/workspace_test.cljs
@@ -9,28 +9,66 @@
   "Create workspace data with Malli defaults, optionally overriding fields"
   [& [overrides]]
   (-> (m/decode schema/WorkspaceSyncData
-                {:workspace {:name "Test Workspace"}}  ; Provide required workspace meta
+                {:workspace {:name "Test Workspace"}}
                 mt/default-value-transformer)
       (merge overrides)
       clj->js))
 
+;; Test helpers for readable assertions
+(defn has-action? [effects action-kw]
+  (some #(= action-kw (first %)) effects))
+
+(defn get-action [effects action-kw]
+  (->> effects
+       (filter #(= action-kw (first %)))
+       first))
+
 (deftest opened-test
-  (testing "Empty workspace initializes new"
-    (let [workspace-data-js (create-workspace-data-js)
-          result (workspace/opened {} workspace-data-js)
-          [[action1 action1-param] [action2]] result]
-      (is (= :workspace.actions/set action1))
-      (is (= {:name "Test Workspace"} action1-param))
-      (is (= :workspace.actions/initialize-empty action2))))
+  (testing "Empty workspace initializes new topic"
+    (let [workspace-data (create-workspace-data-js)
+          effects (workspace/opened {} workspace-data)]
+      (is (has-action? effects :workspace.actions/set))
+      (is (has-action? effects :workspace.actions/initialize-empty))))
 
   (testing "Workspace with topics restores them"
     (let [topic (schema/create-topic)
-          workspace-data-js (create-workspace-data-js {:topics {"tid" topic}})
-          result (workspace/opened {} workspace-data-js)
-          [[action1 action1-param] [action2 action2-param]] result]
-      (is (= :workspace.actions/set action1))
-      (is (= {:name "Test Workspace"} action1-param))
-      (is (= :workspace.actions/restore-with-topics action2))
-      (is (= "tid" (:active-topic-id action2-param)))
-      (is (contains? (:topics action2-param) "tid")))))
+          workspace-data (create-workspace-data-js {:topics {"tid" topic}})
+          effects (workspace/opened {} workspace-data)
+          [_ restore-params] (get-action effects :workspace.actions/restore-with-topics)]
+      (is (has-action? effects :workspace.actions/set))
+      (is (= "tid" (:active-topic-id restore-params)))
+      (is (contains? (:topics restore-params) "tid")))))
+
+(deftest restore-with-topics-test
+  (testing "Passes model from active topic to set-active"
+    (let [topic (assoc (schema/create-topic) :model "claude-3-5-sonnet-20241022")
+          effects (workspace/restore-with-topics {} {:topics          {"tid" topic}
+                                                      :active-topic-id "tid"})
+          [_ topic-id model] (get-action effects :topic.actions/set-active)]
+      (is (= "tid" topic-id))
+      (is (= "claude-3-5-sonnet-20241022" model))))
+
+  (testing "Uses default model from schema when topic created"
+    (let [topic (schema/create-topic)
+          effects (workspace/restore-with-topics {} {:topics          {"tid" topic}
+                                                      :active-topic-id "tid"})
+          [_ _ model] (get-action effects :topic.actions/set-active)]
+      (is (= "anthropic/claude-sonnet-4-5" model)))))
+
+(deftest opened-multiple-topics-test
+  (testing "Selects one topic when multiple exist"
+    (let [topic1 (schema/create-topic)
+          topic2 (schema/create-topic)
+          workspace-data (create-workspace-data-js {:topics {"tid1" topic1
+                                                              "tid2" topic2}})
+          effects (workspace/opened {} workspace-data)
+          [_ restore-params] (get-action effects :workspace.actions/restore-with-topics)
+          selected-id (:active-topic-id restore-params)]
+      (is (contains? #{"tid1" "tid2"} selected-id))
+      (is (= 2 (count (:topics restore-params)))))))
+
+(deftest load-error-test
+  (testing "Returns no effects on error"
+    (let [effects (workspace/load-error {} (js/Error. "Test error"))]
+      (is (empty? effects)))))
 

--- a/test/gremllm/renderer/ui/topics_test.cljs
+++ b/test/gremllm/renderer/ui/topics_test.cljs
@@ -29,4 +29,32 @@
         (is (= "page" (-> active-link lookup/attrs :aria-current))
             "Active topic should set aria-current to 'page'.")))))
 
+(deftest unsaved-and-active-markers-test
+  (let [props  {:workspace       {:name "Work"}
+                :topics-map      {"t1" {:id "t1" :name "Clean"}
+                                  "t2" {:id "t2" :name "Dirty" :unsaved? true}}
+                :active-topic-id "t2"}
+        hiccup (topics-ui/render-left-panel-content props)
+        links  (->> hiccup (lookup/select '[nav > ul > li > a]) rest)]
+    (is (= ["• Clean" "✓ Dirty *"] (map lookup/text links))
+        "Active topics show ✓, inactive show •, unsaved append *")))
+
+(deftest rename-mode-input-test
+  (let [props  {:workspace         {:name "Work"}
+                :topics-map        {"t1" {:id "t1" :name "Alpha"}}
+                :renaming-topic-id "t1"}
+        hiccup (topics-ui/render-left-panel-content props)
+        input  (lookup/select-one '[nav > ul > li > input] hiccup)]
+    (is (= "Alpha" (-> input lookup/attrs :default-value))
+        "Rename mode renders input with topic name as default-value")))
+
+(deftest double-click-rename-action-test
+  (let [props  {:workspace    {:name "Work"}
+                :topics-map   {"t1" {:id "t1" :name "Alpha"}}}
+        hiccup (topics-ui/render-left-panel-content props)
+        link   (->> hiccup (lookup/select '[nav > ul > li > a]) rest first)]
+    (is (= [:topic.actions/begin-rename "t1"]
+           (-> link lookup/attrs (get-in [:on :dblclick 1])))
+        "Double-click dispatches begin-rename action with topic ID")))
+
 


### PR DESCRIPTION
Add tests covering renderer actions and UI: LLM response parsing (msg/llm-response-received), topic rename and auto-save behavior (commit-rename, auto-save), and workspace flows (opened, restore-with-topics, load-error). Tests assert effect sequences, propagate the topic model or default "anthropic/claude-sonnet-4-5" to :topic.actions/set-active, and validate UI markers (active ✓, inactive •, unsaved *), rename input default value, and begin-rename on double-click. Introduces has-action? and get-action helpers for effect assertions; only test files are modified.