### PR TITLE
refactor: add system-info-to-ipc validation at IPC trust boundary

### DIFF
--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -71,7 +71,7 @@
              (-> (system-info
                    (secrets/load-all secrets-filepath)
                    (secrets/check-availability))
-                 ;; TODO: add (system-info-to-ipc) boundary trust fn
+                 (schema/system-info-to-ipc)
                  (clj->js)))))
 
 (defn- setup-system-resources [store]

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -147,6 +147,11 @@
       $)
     (m/coerce SystemInfo $ mt/json-transformer)))
 
+(defn system-info-to-ipc
+  "Validates and prepares system info for IPC transmission. Throws if invalid."
+  [system-info]
+  (m/coerce SystemInfo system-info mt/strip-extra-keys-transformer))
+
 
 ;; ========================================
 ;; Topics & Workspaces


### PR DESCRIPTION
Adds schema/system-info-to-ipc boundary function to validate and strip extra keys before transmission, matching the existing workspace-sync-for-ipc pattern. Ensures fail-fast validation on the main process side before sending data to renderer.