### PR TITLE
refactor: improve delete topic architecture and polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,11 +108,16 @@ Following FCIS principles, all state changes flow through Nexus:
 
 **IPC Channels:**
 - `chat/send-message` - LLM API calls
-- `topic/save` - Save topic to disk
+- `topic/save` - Persist topic to disk
+- `topic/delete` - Remove topic file from disk
 - `workspace/pick-folder` - Folder picker dialog
+- `workspace/reload` - Request refreshed workspace data
+- `workspace:opened` - Broadcast refreshed workspace payload (`onWorkspaceOpened`)
 - `system/get-info` - System capabilities
 - `secrets/save`, `secrets/delete` - Secure storage
 - Menu commands via `onMenuCommand`
+
+Explicit renderer listeners like `onWorkspaceOpened` wrap domain events so the preload boundary exposes intent-driven APIs instead of raw channel strings.
 
 **Data Storage:**
 ```
@@ -177,4 +182,3 @@ Framework and library documentation is available in the `context/` directory:
 - `context/electron_dialog.md` - Native dialogs and file pickers
 - `context/electron_safestorage.md` - Secure credential storage
 - `context/electron_menu.md` - Application menu system
-

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -55,7 +55,16 @@
             margin: 0;
             /* Lean on Pico palette but fall back to subtle gray */
             border-color: var(--pico-color-muted-border, rgba(0, 0, 0, 0.12));
-            color: var(--pico-color-muted-border, rgba(0, 0, 0, 0.12));
+            color: var(--pico-muted-color, rgba(0, 0, 0, 0.12));
+
+            /* Show delete button only on hover */
+            opacity: 0;
+            transition: opacity 0.2s;
+        }
+
+        /* Show delete button only on hover */
+        .topic-item:hover > button {
+            opacity: 1;
         }
 
         @keyframes spin {

--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -43,6 +43,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	pickWorkspaceFolder: () => ipcRenderer.invoke("workspace/pick-folder"),
 	reloadWorkspace: () => ipcRenderer.invoke("workspace/reload"),
 	onMenuCommand: (command, callback) => ipcRenderer.on(command, callback),
+	onWorkspaceOpened: (callback) => ipcRenderer.on("workspace:opened", callback),
 	getSystemInfo: () => ipcRenderer.invoke("system/get-info"),
 	// Secrets API
 	saveSecret: (key, value) => ipcRenderer.invoke("secrets/save", key, value),

--- a/src/gremllm/main/actions/topic.cljs
+++ b/src/gremllm/main/actions/topic.cljs
@@ -3,14 +3,28 @@
   (:require ["path" :as path]
             [gremllm.schema :as schema]))
 
-(defn generate-filename [topic-id]
+(defn topic-filename
+  "Generate filename for a topic (e.g., 'abc123.edn')"
+  [topic-id]
   (str topic-id ".edn"))
 
+(defn topic-filepath
+  "Build full filepath for a topic in given directory"
+  [dir topic-id]
+  (path/join dir (topic-filename topic-id)))
+
 (defn topic->save-plan
+  "Create save plan for persisting a topic"
   [topic-clj topics-dir]
   (let [persisted-topic (schema/topic-for-disk topic-clj)]
     {:dir      topics-dir
-     :filepath (->> (generate-filename (:id persisted-topic))
-                    (path/join topics-dir))
+     :filepath (topic-filepath topics-dir (:id persisted-topic))
      :content  (pr-str persisted-topic)}))
 
+(defn topic->delete-plan
+  "Create delete plan for removing a topic from disk."
+  [topic-id topics-dir]
+  {:topic-id               topic-id
+   :filepath               (topic-filepath topics-dir topic-id)
+   :confirmation-message   "Delete topic?" ;; TODO: include topic-name
+   :confirmation-detail    "This action cannot be undone."})

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -56,5 +56,5 @@
   [_state]
   [[:effects/promise
     {:promise (.pickWorkspaceFolder js/window.electronAPI)}]])
-     ;; No handlers needed - workspace data arrives via workspace:sync IPC event
+     ;; No handlers needed - workspace data arrives via workspace:opened IPC event
 

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -36,13 +36,10 @@
                         :show-settings (nxr/dispatch store {} [[:ui.actions/show-settings]])
                         nil)))
 
-    ;; TODO: 'workspace:sync' isn't a menu command, we're over-stretching this abstraction...
-    ;; refactor
-
     ;; Handle workspace sync from main process
-    (.onMenuCommand js/window.electronAPI "workspace:sync"
-                    (fn [_ topics-data]
-                      (nxr/dispatch store {} [[:workspace.actions/opened topics-data]])))
+    (.onWorkspaceOpened js/window.electronAPI
+                        (fn [_ topics-data]
+                          (nxr/dispatch store {} [[:workspace.actions/opened topics-data]])))
 
     ;; Render on every change
     (add-watch store ::render-topic

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -179,6 +179,16 @@
     [:map
      [:unsaved? {:optional true} :boolean]]))
 
+;; TODO: refactor with (generate-topic-id)
+(def TopicId
+  "Schema for topic identifiers shared across IPC boundaries."
+  [:string {:min 1}])
+
+(defn topic-id-from-ipc
+  "Validates topic identifier received via IPC. Throws if invalid."
+  [topic-id]
+  (m/coerce TopicId (js->clj topic-id) mt/json-transformer))
+
 (defn create-topic []
   (m/decode Topic {} mt/default-value-transformer))
 

--- a/test/gremllm/main/effects/workspace_test.cljs
+++ b/test/gremllm/main/effects/workspace_test.cljs
@@ -121,5 +121,5 @@
           ;; Verify IPC effect
           (let [[[effect-key channel data]] @dispatched]
             (is (= :ipc.effects/send-to-renderer effect-key))
-            (is (= "workspace:sync" channel))
+            (is (= "workspace:opened" channel))
             (is (contains? data :topics))))))))

--- a/test/gremllm/renderer/ui/topics_test.cljs
+++ b/test/gremllm/renderer/ui/topics_test.cljs
@@ -35,7 +35,7 @@
                                   "t2" {:id "t2" :name "Dirty" :unsaved? true}}
                 :active-topic-id "t2"}
         hiccup (topics-ui/render-left-panel-content props)
-        links  (->> hiccup (lookup/select '[nav > ul > li > a]) rest)]
+        links  (->> hiccup (lookup/select '[nav > ul > li a]) rest)]
     (is (= ["• Clean" "✓ Dirty *"] (map lookup/text links))
         "Active topics show ✓, inactive show •, unsaved append *")))
 
@@ -52,7 +52,7 @@
   (let [props  {:workspace    {:name "Work"}
                 :topics-map   {"t1" {:id "t1" :name "Alpha"}}}
         hiccup (topics-ui/render-left-panel-content props)
-        link   (->> hiccup (lookup/select '[nav > ul > li > a]) rest first)]
+        link   (->> hiccup (lookup/select '[nav > ul > li a]) rest first)]
     (is (= [:topic.actions/begin-rename "t1"]
            (-> link lookup/attrs (get-in [:on :dblclick 1])))
         "Double-click dispatches begin-rename action with topic ID")))


### PR DESCRIPTION
Architectural improvements:
- Extract pure helpers following FCIS principles
- Consolidate topic filepath logic in topic actions
- Introduce TopicId schema and topic->delete-plan
- Improve workspace IPC abstraction with onWorkspaceOpened

Polish and cleanup:
- Hover-only delete button visibility
- Fixed test selectors after DOM changes
- Documentation updates for IPC channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)