### PR TITLE
Refactor: Move renderer Dataspex wiring to a dev-only entrypoint

### DIFF
--- a/dev/gremllm/renderer/dev.cljs
+++ b/dev/gremllm/renderer/dev.cljs
@@ -1,7 +1,10 @@
 (ns gremllm.renderer.dev
-  "Browser-only development tooling. Required by renderer/core for side effects."
-  (:require [nexus.action-log :as action-log]
+  "Development entry point for renderer. Adds dev tooling then delegates to core."
+  (:require [gremllm.renderer.core :as core]
+            [nexus.action-log :as action-log]
             [dataspex.core :as dataspex]))
 
-(action-log/inspect)
-(dataspex/connect-remote-inspector)
+(defn ^:export main []
+  (action-log/inspect)
+  (dataspex/connect-remote-inspector)
+  (core/main))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Quantisan, LLC",
   "main": "target/main.js",
   "scripts": {
-    "dev": "concurrently \"shadow-cljs watch main-dev renderer\" \"sleep 10 && ELECTRON_IS_DEV=1 electron-forge start\" \"clj -A:dev -M dev/start_dataspex.clj\" \"sleep 5 && open http://localhost:7117\"",
+    "dev": "concurrently \"shadow-cljs watch main-dev renderer-dev\" \"sleep 10 && ELECTRON_IS_DEV=1 electron-forge start\" \"clj -A:dev -M dev/start_dataspex.clj\" \"sleep 5 && open http://localhost:7117\"",
     "build": "npm run clean && shadow-cljs compile main renderer",
     "package": "npm run build && electron-forge package",
     "make": "npm run build && electron-forge make",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,6 +14,11 @@
              :asset-path "js"
              :modules {:renderer {:init-fn gremllm.renderer.core/main}}}
 
+  :renderer-dev {:target :browser
+                 :output-dir "resources/public/compiled-js"
+                 :asset-path "js"
+                 :modules {:renderer {:init-fn gremllm.renderer.dev/main}}}
+
   :test {:target :node-test
          :output-to "target/test.js"
          :ns-regexp "(?<!integration)-test$"

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -3,7 +3,6 @@
             [nexus.registry :as nxr]
             [gremllm.renderer.ui :as ui]
             [gremllm.renderer.actions]
-            [gremllm.renderer.dev]
             [gremllm.schema :as schema]
             [gremllm.renderer.state.topic :as topic-state]))
 


### PR DESCRIPTION
Add a renderer-dev Shadow build that starts with gremllm.renderer.dev/main, wiring action-log inspection and Dataspex remote inspector.

Fixes regression in #151 where tests are unable to run.