### PR TITLE
feat(google): Update Gemini models from 2.5 to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Right now it's just a basic chat interface. The branching features aren't built 
 Not useful yet.
 
 **What works:**
-- Chat with Claude 4.x, GPT-5, or Gemini 2.5
+- Chat with Claude 4.x, GPT-5, or Gemini 3
 - Basic desktop app with Electron
 - Message history during a session
 

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -12,8 +12,8 @@
    "claude-haiku-4-5-20251001"  "Claude 4.5 Haiku"
    "gpt-5"                      "GPT-5"
    "gpt-5-mini"                 "GPT-5 Mini"
-   "gemini-2.5-flash"           "Gemini 2.5 Flash"
-   "gemini-2.5-pro"             "Gemini 2.5 Pro"})
+   "gemini-3-flash-preview"     "Gemini 3 Flash"
+   "gemini-3-pro-preview"       "Gemini 3 Pro"})
 
 ;; ========================================
 ;; Messages
@@ -265,7 +265,7 @@
   [:map
    [:id {:default/fn generate-topic-id} :string]
    [:name {:default "New Topic"} :string]
-   [:model {:default "gemini-2.5-flash"} ;; defaulting to Flash because is cheap and fast
+   [:model {:default "gemini-3-flash-preview"} ;; defaulting to Flash because is cheap and fast
     (into [:enum] (keys supported-models))]
    [:messages {:default []} [:vector Message]]])
 

--- a/test/gremllm/main/effects/llm_integration_test.cljs
+++ b/test/gremllm/main/effects/llm_integration_test.cljs
@@ -151,7 +151,7 @@
   (async done
     (testing "INTEGRATION: validate Gemini API structure matches mock fixture"
       (with-provider-api
-        {:name "Gemini" :env-key "GEMINI_API_KEY" :model "gemini-2.5-flash-lite"}
+        {:name "Gemini" :env-key "GEMINI_API_KEY" :model "gemini-3-flash-preview"}
         (fn [response]
           (assert-matches-structure response mock-gemini-response
                                     []
@@ -184,7 +184,7 @@
   "Provider configurations for markdown attachment integration tests."
   {:gemini    {:name "Gemini"
                :env-key "GEMINI_API_KEY"
-               :model "gemini-2.5-flash-lite"
+               :model "gemini-3-flash-preview"
                :include-filename? false}
    :openai    {:name "OpenAI"
                :env-key "OPENAI_API_KEY"

--- a/test/gremllm/main/effects/llm_test.cljs
+++ b/test/gremllm/main/effects/llm_test.cljs
@@ -89,9 +89,10 @@
    :usageMetadata {:promptTokenCount 4
                    :candidatesTokenCount 1
                    :totalTokenCount 24
+                   :thoughtsTokenCount 0
                    :promptTokensDetails [{:modality "TEXT"
                                           :tokenCount 4}]}
-   :modelVersion "gemini-2.5-flash-lite"
+   :modelVersion "gemini-3-flash-preview"
    :responseId "tpboaMabLejN1e8PzMOD0Ak"})
 
 ;; Unit Tests
@@ -382,7 +383,7 @@
   (testing "successfully parses and normalizes Gemini API response"
     (let [original-fetch js/fetch
           test-messages  [{:role "user" :content "2+2"}]
-          test-model     "gemini-2.5-flash"
+          test-model     "gemini-3-flash-preview"
           test-api-key   "test-key"]
 
       (set! js/fetch (mock-successful-fetch mock-gemini-response))


### PR DESCRIPTION
Update supported models to Gemini 3 (currently in preview). Model IDs now use `gemini-3-flash-preview` and `gemini-3-pro-preview`. Add `thoughtsTokenCount` field to mock Gemini response fixture to match current API.