### PR TITLE
Display reasoning messages with collapsible, visually distinct UI

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -31,6 +31,12 @@
             max-width: 70%;
         }
 
+        .reasoning-bubble {
+            background: var(--pico-muted-background);
+            opacity: 0.85;
+            border-left: 3px solid var(--pico-muted-border-color);
+        }
+
         textarea.chat-input {
             field-sizing: content;
             max-height: calc(1.5em * 16);

--- a/src/gremllm/renderer/ui/chat.cljs
+++ b/src/gremllm/renderer/ui/chat.cljs
@@ -24,8 +24,9 @@
   [e/assistant-message
     [:div {:innerHTML (markdown->html (:text message))}]])
 
-;; TODO:
-(def render-reasoning-message render-assistant-message)
+(defn- render-reasoning-message [message]
+  [e/reasoning-message {}
+   [:div {:innerHTML (markdown->html (:text message))}]])
 
 (defn- render-message [message]
   (case (:type message)

--- a/src/gremllm/renderer/ui/elements.cljs
+++ b/src/gremllm/renderer/ui/elements.cljs
@@ -58,3 +58,12 @@
 (defalias assistant-message [attrs & body]
   [:div.message-container
    (into [:article attrs] body)])
+
+(defalias reasoning-message [attrs & body]
+  [:div.message-container
+   [:article.reasoning-bubble
+    [:details (merge {:open true} attrs)
+     [:summary {:style {:cursor "pointer"
+                        :color "var(--pico-muted-color)"}}
+      "Reasoning ..."]
+     (into [:div] body)]]])


### PR DESCRIPTION
Implements rendering for `:reasoning` message types (extended thinking chunks) with clear visual distinction from assistant responses. Reasoning messages appear as muted, collapsible bubbles with a left border anchor, expanded by default but user-collapsible.

This completes the UI layer for the extended thinking feature, allowing users to see Claude's reasoning process when enabled while keeping it visually subordinate to actual responses.