### PR TITLE
refactor: split IPC/ACP codecs into a new gremllm.schema.codec ns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Why PE due diligence:
 | UI | - | `renderer.ui.*` - chat, settings, topics |
 | Effects | `main.effects.*` - ACP, file I/O | (handled in actions) |
 | Schema | `schema` - data models, validation | (shared) |
+| Codec | `schema.codec` - IPC/JS/ACP adaptation and codecs | (shared) |
 
 **ACP Integration (current implementation):**
 - One ACP session per topic; the topic stores the `acp-session-id`
@@ -170,7 +171,7 @@ Explicit renderer listeners like `onWorkspaceOpened` and `onAcpSessionUpdate` wr
 
 - **Workspaces:** Portable folders, like git repos - can live anywhere
 - **Topics:** Individual EDN files in `topics/` subdirectory (includes `acp-session-id` and local message history)
-- **Schemas:** See `schema.cljs` for data structures
+- **Schemas:** See `schema.cljs` for data structures; transport/IPC codecs live in `schema/codec.cljs`
 - **File I/O:** See `main/io.cljs` for paths and operations
 
 ## Entry Points
@@ -180,6 +181,7 @@ Explicit renderer listeners like `onWorkspaceOpened` and `onAcpSessionUpdate` wr
 - `src/gremllm/renderer/ui.cljs` - Main UI components
 - `src/gremllm/*/actions.cljs` - Action/effect registrations
 - `src/gremllm/schema.cljs` - Data models and validation
+- `src/gremllm/schema/codec.cljs` - IPC/JS/ACP codecs and adapters
 
 ## UI Approach
 - **PicoCSS + split palette** - Semantic HTML with PicoCSS defaults. A TVA/Brutalist palette defines light zones (document panel) and dark zones (nav, chat). Element aliases in `elements.cljs` handle zone scoping automatically — don't set `data-theme` manually.

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -7,7 +7,7 @@
             [gremllm.main.menu :as menu]
             [gremllm.main.io :as io]
             [gremllm.main.state :as state]
-            [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]
             [nexus.registry :as nxr]
             ["electron/main" :refer [app BrowserWindow ipcMain]]))
 
@@ -45,7 +45,7 @@
            (fn [_event topic-data]
              (let [workspace-dir (state/get-workspace-dir @store)]
                (-> (js->clj topic-data :keywordize-keys true)
-                   (schema/topic-from-ipc)
+                   (codec/topic-from-ipc)
                    (topic-actions/topic->save-plan (io/topics-dir-path workspace-dir))
                    (workspace-effects/save-topic)))))
 
@@ -54,7 +54,7 @@
              (let [workspace-dir (state/get-workspace-dir @store)
                    topics-dir    (io/topics-dir-path workspace-dir)]
                (-> topic-id
-                   (schema/topic-id-from-ipc)
+                   (codec/topic-id-from-ipc)
                    (topic-actions/topic->delete-plan topics-dir)
                    (workspace-effects/delete-topic-with-confirmation)))))
 
@@ -88,7 +88,7 @@
              (-> (system-info
                    (secrets/load-all secrets-filepath)
                    (secrets/check-availability))
-                 (schema/system-info-to-ipc)
+                 (codec/system-info-to-ipc)
                  (clj->js))))
 
   ;; ACP - async pattern: dispatch to actions, response flows via IPC reply
@@ -124,7 +124,7 @@
     ;; (silently ignored by Nexus). Add a whitelist if this causes debugging pain.
     (acp-effects/set-dispatcher!
       (fn [event-type data]
-        (let [coerced (schema/acp-session-update-from-js data)]
+        (let [coerced (codec/acp-session-update-from-js data)]
           (nxr/dispatch store {} [[(keyword event-type) coerced]]))))))
 
 (defn- initialize-app [store]

--- a/src/gremllm/main/effects/workspace.cljs
+++ b/src/gremllm/main/effects/workspace.cljs
@@ -5,7 +5,8 @@
   ;; Loaded dynamically to support testing outside Electron environment
   (:require [gremllm.main.io :as io]
             [clojure.edn :as edn]
-            [gremllm.schema :as schema]))
+            [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Private Helpers
@@ -142,5 +143,5 @@
         workspace-meta (schema/create-workspace-meta workspace-name)
         document       (read-document workspace-path)
         topics         (-> workspace-path io/topics-dir-path load-topics)
-        sync-payload   (schema/workspace-sync-for-ipc topics workspace-meta document)]
+        sync-payload   (codec/workspace-sync-for-ipc topics workspace-meta document)]
     (dispatch [[:ipc.effects/send-to-renderer "workspace:opened" sync-payload]])))

--- a/src/gremllm/renderer/actions/acp.cljs
+++ b/src/gremllm/renderer/actions/acp.cljs
@@ -2,6 +2,7 @@
   "Actions for managing ACP (Agent Client Protocol) sessions."
   (:require [malli.core :as m]
             [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]
             [gremllm.renderer.state.topic :as topic-state]))
 
 (defn- continuing? [state message-type]
@@ -38,12 +39,12 @@
 (defn session-update
   "Handles incoming ACP session updates (streaming chunks, errors, etc).
 
-  update: schema/AcpUpdate"
+  update: codec/AcpUpdate"
   [state {:keys [update]}]
-  (when-let [message-type (get schema/acp-chunk->message-type (:session-update update))]
+  (when-let [message-type (get codec/acp-chunk->message-type (:session-update update))]
     (streaming-chunk-effects state
                              message-type
-                             (schema/acp-update-text update)
+                             (codec/acp-update-text update)
                              (.now js/Date))))
 
 (defn session-ready

--- a/src/gremllm/renderer/actions/system.cljs
+++ b/src/gremllm/renderer/actions/system.cljs
@@ -1,9 +1,9 @@
 (ns gremllm.renderer.actions.system
   (:require [gremllm.renderer.state.system :as system-state]
-            [gremllm.schema :as schema]))
+            [gremllm.schema.codec :as codec]))
 
 (defn set-info [_state system-info-js]
-  [[:effects/save system-state/system-info-path (schema/system-info-from-ipc system-info-js)]])
+  [[:effects/save system-state/system-info-path (codec/system-info-from-ipc system-info-js)]])
 
 (defn request-info [_state]
   [[:effects/promise
@@ -13,4 +13,3 @@
 
 (defn request-error [_state error]
   [[:ui.effects/console-error "Failed to get system info:" error]])
-

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -3,7 +3,8 @@
             [clojure.string :as str]
             [gremllm.renderer.state.topic :as topic-state]
             [gremllm.renderer.state.ui :as ui-state]
-            [gremllm.schema :as schema]))
+            [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]))
 
 (defn start-new-topic [_state]
   (let [new-topic (schema/create-topic)
@@ -87,9 +88,9 @@
 (nxr/register-effect! :topic.effects/save-topic
   (fn [{dispatch :dispatch} store topic-id]
     (if-let [topic (topic-state/get-topic @store topic-id)]
-      (dispatch
+        (dispatch
        [[:effects/promise
-         {:promise    (.saveTopic js/window.electronAPI (schema/topic-to-ipc topic))
+         {:promise    (.saveTopic js/window.electronAPI (codec/topic-to-ipc topic))
           :on-success [[:topic.actions/save-success topic-id]]
           :on-error   [[:topic.actions/save-error topic-id]]}]])
       (dispatch [[:topic.actions/save-error topic-id (js/Error. (str "Topic not found: " topic-id))]]))))

--- a/src/gremllm/renderer/actions/workspace.cljs
+++ b/src/gremllm/renderer/actions/workspace.cljs
@@ -1,5 +1,5 @@
 (ns gremllm.renderer.actions.workspace
-  (:require [gremllm.schema :as schema]
+  (:require [gremllm.schema.codec :as codec]
             [gremllm.renderer.state.workspace :as workspace-state]
             [gremllm.renderer.state.topic :as topic-state]))
 
@@ -19,7 +19,7 @@
 (defn opened
   "A workspace folder has been opened/loaded from disk."
   [_state workspace-data-js]
-  (let [{:keys [topics workspace document]} (schema/workspace-sync-from-ipc workspace-data-js)]
+  (let [{:keys [topics workspace document]} (codec/workspace-sync-from-ipc workspace-data-js)]
     (cond-> [[:workspace.actions/set workspace]
              [:document.actions/set-content document]]
       (empty? topics) (conj [:workspace.actions/initialize-empty])
@@ -52,4 +52,3 @@
   [[:effects/promise
     {:promise (.pickWorkspaceFolder js/window.electronAPI)}]])
      ;; No handlers needed - workspace data arrives via workspace:opened IPC event
-

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -4,6 +4,7 @@
             [gremllm.renderer.ui :as ui]
             [gremllm.renderer.actions]
             [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]
             [gremllm.renderer.state.topic :as topic-state]))
 
 ;; State Shape Documentation
@@ -47,7 +48,7 @@
     ;; Handle ACP session updates from main process
     (.onAcpSessionUpdate js/window.electronAPI
                          (fn [_ event-data]
-                           (nxr/dispatch store {} [[:acp.events/session-update (schema/acp-session-update-from-ipc event-data)]])))
+                           (nxr/dispatch store {} [[:acp.events/session-update (codec/acp-session-update-from-ipc event-data)]])))
 
     ;; Render on every change
     (add-watch store ::render-topic

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -1,6 +1,5 @@
 (ns gremllm.schema
-  (:require [camel-snake-kebab.core :as csk]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.string :as str]
             [malli.core :as m]
             [malli.transform :as mt]
@@ -32,12 +31,6 @@
 
 (def Messages
   [:vector Message])
-
-(defn messages-from-ipc
-  [messages-js]
-  (as-> messages-js $
-    (js->clj $ :keywordize-keys true)
-    (m/coerce Messages $ mt/json-transformer)))
 
 ;; ========================================
 ;; Providers
@@ -103,50 +96,6 @@
   [:map
    [:api-keys {:optional true} APIKeysMap]])
 
-(def FlatSecrets
-  "Secrets structure as received from IPC (main process).
-   Flat map with provider-specific key names.
-   Derived from provider-storage-key-map."
-  (into [:map]
-        (map (fn [[_provider storage-key]]
-               [storage-key {:optional true} [:maybe :string]])
-             provider-storage-key-map)))
-
-(def SystemInfo
-  "System info structure as received from main process.
-   Contains platform capabilities and secrets."
-  [:map
-   [:encryption-available? :boolean]
-   [:secrets {:optional true} FlatSecrets]])
-
-(defn secrets-from-ipc
-  "Transforms flat IPC secrets to nested api-keys structure. Throws if invalid.
-   {:anthropic-api-key 'sk-ant-xyz'} → {:api-keys {:anthropic 'sk-ant-xyz'}}"
-  [flat-secrets]
-  (m/coerce NestedSecrets
-    {:api-keys (into {}
-                 (keep (fn [provider]
-                         (when-let [value (get flat-secrets (provider->api-key-keyword provider))]
-                           [provider value]))
-                       supported-providers))}
-    mt/json-transformer))
-
-(defn system-info-from-ipc
-  "Validates system info from IPC and transforms secrets. Throws if invalid."
-  [system-info-js]
-  (as-> system-info-js $
-    (js->clj $ :keywordize-keys true)
-    (if (:secrets $)
-      (update $ :secrets secrets-from-ipc)
-      $)
-    (m/coerce SystemInfo $ mt/json-transformer)))
-
-(defn system-info-to-ipc
-  "Validates and prepares system info for IPC transmission. Throws if invalid."
-  [system-info]
-  (m/coerce SystemInfo system-info mt/strip-extra-keys-transformer))
-
-
 ;; ========================================
 ;; Topics & Workspaces
 ;; ========================================
@@ -178,11 +127,6 @@
   "Schema for topic identifiers shared across IPC boundaries."
   [:string {:min 1}])
 
-(defn topic-id-from-ipc
-  "Validates topic identifier received via IPC. Throws if invalid."
-  [topic-id]
-  (m/coerce TopicId (js->clj topic-id) mt/json-transformer))
-
 (defn create-topic []
   (m/decode Topic {} mt/default-value-transformer))
 
@@ -194,43 +138,10 @@
 (defn valid-workspace-topics? [topics-map]
   (m/validate WorkspaceTopics topics-map))
 
-(def WorkspaceSyncData
-  "Schema for workspace data sent from main to renderer via IPC.
-   Used when loading a workspace folder from disk."
-  [:map
-   [:workspace [:map [:name :string]]]
-   [:topics {:default {}} WorkspaceTopics]
-   [:document {:default {:content nil}} [:map [:content [:maybe :string]]]]])
-
 (defn create-workspace-meta
   "Constructor for workspace metadata kept at [:workspace] and sent over IPC."
   [name]
   {:name name})
-
-(defn topic-to-ipc [topic-clj]
-  (-> (m/coerce Topic topic-clj mt/json-transformer)
-      (clj->js)))
-
-(defn topic-from-ipc
-  "Transforms topic data from IPC into internal Topic schema. Throws if invalid."
-  [topic-js]
-  (as-> topic-js $
-    (js->clj $ :keywordize-keys true)
-    (m/coerce Topic $ mt/json-transformer)))
-
-(defn workspace-sync-from-ipc
-  "Validates and transforms workspace sync data from IPC. Throws if invalid."
-  [workspace-data-js]
-  (as-> workspace-data-js $
-    (js->clj $ :keywordize-keys true)
-    (m/coerce WorkspaceSyncData $ mt/json-transformer)))
-
-(defn workspace-sync-for-ipc
-  "Validates and prepares workspace sync data for IPC transmission. Throws if invalid."
-  [topics workspace document]
-  (m/coerce WorkspaceSyncData
-            {:topics topics :workspace workspace :document document}
-            mt/strip-extra-keys-transformer))
 
 (def topic-from-disk
   "Loads and validates a topic from persisted EDN format.
@@ -240,112 +151,3 @@
 (def topic-for-disk
   "Prepares topic for disk persistence, stripping transient fields. Throws if invalid."
   (m/coercer PersistedTopic mt/strip-extra-keys-transformer))
-
-;; ========================================
-;; ACP Session Updates
-;; ========================================
-
-(def acp-chunk->message-type
-  "Maps ACP content chunk session-update types to internal MessageType.
-   Only includes session updates that produce chat messages."
-  {:agent-message-chunk :assistant
-   :agent-thought-chunk :reasoning})
-
-(defn acp-update-text
-  "Extracts text content from an ACP update chunk.
-
-   update: AcpUpdate
-
-   Returns nil for update types without text content.
-   TODO: If AcpUpdate becomes a Record, convert to protocol getter."
-  [update]
-  (get-in update [:content :text]))
-
-;; ACP Update sub-schemas
-(def AcpCommandInput
-  "Optional input schema for ACP commands."
-  [:map
-   [:hint {:optional true} :string]])
-
-(def AcpCommand
-  "Schema for an ACP command definition."
-  [:map
-   [:name :string]
-   [:description :string]
-   [:input {:optional true} [:maybe AcpCommandInput]]])
-
-(def AcpTextContent
-  "Schema for text content in ACP chunks."
-  [:map
-   [:type [:= "text"]]
-   [:text :string]
-   [:annotations {:optional true} [:maybe :any]]
-   [:_meta {:optional true} [:maybe [:map-of :keyword :any]]]])
-
-(def AcpUpdate
-  "Discriminated union of ACP session update types.
-   Dispatches on :session-update field."
-  [:multi {:dispatch (fn [m]
-                       ;; Convert raw string/keyword to kebab-case keyword for dispatch.
-                       ;; Dispatch runs BEFORE transformers, expects raw keys:
-                       ;; - "sessionUpdate" from ACP JS module (camelCase string)
-                       ;; - "session-update" over IPC from main (kebab string via clj->js)
-                       ;; - :session-update when data already in CLJS form (internal validation, tests)
-                       (some-> (or (:session-update m)
-                                   (get m "sessionUpdate")
-                                   (get m "session-update"))
-                               csk/->kebab-case
-                               keyword))}
-   [:available-commands-update
-    [:map
-     [:session-update [:= :available-commands-update]]
-     [:available-commands [:vector AcpCommand]]]]
-
-   [:agent-thought-chunk
-    [:map
-     [:session-update [:= :agent-thought-chunk]]
-     [:content AcpTextContent]]]
-
-   [:agent-message-chunk
-    [:map
-     [:session-update [:= :agent-message-chunk]]
-     [:content AcpTextContent]]]])
-
-(def AcpSessionUpdate
-  "Schema for session updates from ACP."
-  [:map
-   [:acp-session-id :string] ;; TODO: :uuid type
-   [:update AcpUpdate]])
-
-(def ^:private acp-key-transformer
-  "Maps sessionId → :acp-session-id, otherwise camel→kebab."
-  (mt/key-transformer
-    {:decode (fn [k]
-               (if (= k "sessionId")
-                 :acp-session-id
-                 (csk/->kebab-case-keyword k)))}))
-
-(def ^:private session-update-value-transformer
-  "Transforms :session-update string values to kebab-case keywords."
-  (mt/transformer
-    {:name :session-update
-     :decoders {:map (fn [x]
-                       (if (and (map? x) (string? (:session-update x)))
-                         (update x :session-update (comp keyword csk/->kebab-case))
-                         x))}}))
-
-(defn acp-session-update-from-js
-  "Coerce ACP session update from JS dispatcher bridge."
-  [js-data]
-  ;; Keep this pure Malli; dispatch handles raw keys before transformer runs.
-  (m/coerce AcpSessionUpdate
-            (js->clj js-data)
-            (mt/transformer
-              acp-key-transformer
-              session-update-value-transformer
-              mt/json-transformer)))
-
-(defn acp-session-update-from-ipc
-  "Validates and transforms ACP session update from IPC. Throws if invalid."
-  [event-data-js]
-  (acp-session-update-from-js event-data-js))

--- a/src/gremllm/schema/codec.cljs
+++ b/src/gremllm/schema/codec.cljs
@@ -1,0 +1,205 @@
+(ns gremllm.schema.codec
+  (:require [camel-snake-kebab.core :as csk]
+            [gremllm.schema :as schema]
+            [malli.core :as m]
+            [malli.transform :as mt]))
+
+;; ========================================
+;; IPC Codecs
+;; ========================================
+
+(defn messages-from-ipc
+  [messages-js]
+  (as-> messages-js $
+    (js->clj $ :keywordize-keys true)
+    (m/coerce schema/Messages $ mt/json-transformer)))
+
+(def FlatSecrets
+  "Secrets structure as received from IPC (main process).
+   Flat map with provider-specific key names.
+   Derived from provider-storage-key-map."
+  (into [:map]
+        (map (fn [[_provider storage-key]]
+               [storage-key {:optional true} [:maybe :string]])
+             schema/provider-storage-key-map)))
+
+(def SystemInfo
+  "System info structure as received from main process.
+   Contains platform capabilities and secrets."
+  [:map
+   [:encryption-available? :boolean]
+   [:secrets {:optional true} FlatSecrets]])
+
+(defn secrets-from-ipc
+  "Transforms flat IPC secrets to nested api-keys structure. Throws if invalid.
+   {:anthropic-api-key 'sk-ant-xyz'} → {:api-keys {:anthropic 'sk-ant-xyz'}}"
+  [flat-secrets]
+  (m/coerce schema/NestedSecrets
+            {:api-keys (into {}
+                             (keep (fn [provider]
+                                     (when-let [value (get flat-secrets (schema/provider->api-key-keyword provider))]
+                                       [provider value]))
+                                   schema/supported-providers))}
+            mt/json-transformer))
+
+(defn system-info-from-ipc
+  "Validates system info from IPC and transforms secrets. Throws if invalid."
+  [system-info-js]
+  (as-> system-info-js $
+    (js->clj $ :keywordize-keys true)
+    (if (:secrets $)
+      (update $ :secrets secrets-from-ipc)
+      $)
+    (m/coerce SystemInfo $ mt/json-transformer)))
+
+(defn system-info-to-ipc
+  "Validates and prepares system info for IPC transmission. Throws if invalid."
+  [system-info]
+  (m/coerce SystemInfo system-info mt/strip-extra-keys-transformer))
+
+(defn topic-id-from-ipc
+  "Validates topic identifier received via IPC. Throws if invalid."
+  [topic-id]
+  (m/coerce schema/TopicId (js->clj topic-id) mt/json-transformer))
+
+(def WorkspaceSyncData
+  "Schema for workspace data sent from main to renderer via IPC.
+   Used when loading a workspace folder from disk."
+  [:map
+   [:workspace [:map [:name :string]]]
+   [:topics {:default {}} schema/WorkspaceTopics]
+   [:document {:default {:content nil}} [:map [:content [:maybe :string]]]]])
+
+(defn topic-to-ipc [topic-clj]
+  (-> (m/coerce schema/Topic topic-clj mt/json-transformer)
+      (clj->js)))
+
+(defn topic-from-ipc
+  "Transforms topic data from IPC into internal Topic schema. Throws if invalid."
+  [topic-js]
+  (as-> topic-js $
+    (js->clj $ :keywordize-keys true)
+    (m/coerce schema/Topic $ mt/json-transformer)))
+
+(defn workspace-sync-from-ipc
+  "Validates and transforms workspace sync data from IPC. Throws if invalid."
+  [workspace-data-js]
+  (as-> workspace-data-js $
+    (js->clj $ :keywordize-keys true)
+    (m/coerce WorkspaceSyncData $ mt/json-transformer)))
+
+(defn workspace-sync-for-ipc
+  "Validates and prepares workspace sync data for IPC transmission. Throws if invalid."
+  [topics workspace document]
+  (m/coerce WorkspaceSyncData
+            {:topics topics :workspace workspace :document document}
+            mt/strip-extra-keys-transformer))
+
+;; ========================================
+;; ACP Session Updates
+;; ========================================
+
+(def acp-chunk->message-type
+  "Maps ACP content chunk session-update types to internal MessageType.
+   Only includes session updates that produce chat messages."
+  {:agent-message-chunk :assistant
+   :agent-thought-chunk :reasoning})
+
+(defn acp-update-text
+  "Extracts text content from an ACP update chunk.
+
+   update: AcpUpdate
+
+   Returns nil for update types without text content.
+   TODO: If AcpUpdate becomes a Record, convert to protocol getter."
+  [update]
+  (get-in update [:content :text]))
+
+;; ACP Update sub-schemas
+(def AcpCommandInput
+  "Optional input schema for ACP commands."
+  [:map
+   [:hint {:optional true} :string]])
+
+(def AcpCommand
+  "Schema for an ACP command definition."
+  [:map
+   [:name :string]
+   [:description :string]
+   [:input {:optional true} [:maybe AcpCommandInput]]])
+
+(def AcpTextContent
+  "Schema for text content in ACP chunks."
+  [:map
+   [:type [:= "text"]]
+   [:text :string]
+   [:annotations {:optional true} [:maybe :any]]
+   [:_meta {:optional true} [:maybe [:map-of :keyword :any]]]])
+
+(def AcpUpdate
+  "Discriminated union of ACP session update types.
+   Dispatches on :session-update field."
+  [:multi {:dispatch (fn [m]
+                       ;; Convert raw string/keyword to kebab-case keyword for dispatch.
+                       ;; Dispatch runs BEFORE transformers, expects raw keys:
+                       ;; - \"sessionUpdate\" from ACP JS module (camelCase string)
+                       ;; - \"session-update\" over IPC from main (kebab string via clj->js)
+                       ;; - :session-update when data already in CLJS form (internal validation, tests)
+                       (some-> (or (:session-update m)
+                                   (get m "sessionUpdate")
+                                   (get m "session-update"))
+                               csk/->kebab-case
+                               keyword))}
+   [:available-commands-update
+    [:map
+     [:session-update [:= :available-commands-update]]
+     [:available-commands [:vector AcpCommand]]]]
+
+   [:agent-thought-chunk
+    [:map
+     [:session-update [:= :agent-thought-chunk]]
+     [:content AcpTextContent]]]
+
+   [:agent-message-chunk
+    [:map
+     [:session-update [:= :agent-message-chunk]]
+     [:content AcpTextContent]]]])
+
+(def AcpSessionUpdate
+  "Schema for session updates from ACP."
+  [:map
+   [:acp-session-id :string] ;; TODO: :uuid type
+   [:update AcpUpdate]])
+
+(def ^:private acp-key-transformer
+  "Maps sessionId → :acp-session-id, otherwise camel→kebab."
+  (mt/key-transformer
+    {:decode (fn [k]
+               (if (= k "sessionId")
+                 :acp-session-id
+                 (csk/->kebab-case-keyword k)))}))
+
+(def ^:private session-update-value-transformer
+  "Transforms :session-update string values to kebab-case keywords."
+  (mt/transformer
+    {:name :session-update
+     :decoders {:map (fn [x]
+                       (if (and (map? x) (string? (:session-update x)))
+                         (update x :session-update (comp keyword csk/->kebab-case))
+                         x))}}))
+
+(defn acp-session-update-from-js
+  "Coerce ACP session update from JS dispatcher bridge."
+  [js-data]
+  ;; Keep this pure Malli; dispatch handles raw keys before transformer runs.
+  (m/coerce AcpSessionUpdate
+            (js->clj js-data)
+            (mt/transformer
+              acp-key-transformer
+              session-update-value-transformer
+              mt/json-transformer)))
+
+(defn acp-session-update-from-ipc
+  "Validates and transforms ACP session update from IPC. Throws if invalid."
+  [event-data-js]
+  (acp-session-update-from-js event-data-js))

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -4,6 +4,7 @@
             [gremllm.renderer.state.topic :as topic-state]
             [gremllm.renderer.state.ui :as ui-state]
             [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]
             [malli.core :as m])
   (:require-macros [gremllm.test-utils :refer [with-console-error-silenced]]))
 
@@ -29,7 +30,7 @@
         expected     (assoc expected-new-topic
                             :messages [{:id 1 :type :user :text "test"}
                                        {:id 2 :type :assistant :text "response"}])]
-    (is (= expected (schema/topic-from-ipc denormalized))
+    (is (= expected (codec/topic-from-ipc denormalized))
         "should convert message types from strings to keywords")))
 
 (deftest commit-rename-test
@@ -86,4 +87,3 @@
             actions  (topic/delete-topic-error state topic-id error)]
         (is (= [] actions)
             "should return empty actions vector")))))
-

--- a/test/gremllm/renderer/actions/workspace_test.cljs
+++ b/test/gremllm/renderer/actions/workspace_test.cljs
@@ -2,6 +2,7 @@
   (:require [gremllm.renderer.actions.workspace :as workspace]
             [gremllm.test-utils :refer [with-console-error-silenced]]
             [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]
             [cljs.test :refer [deftest is testing]]
             [malli.core :as m]
             [malli.transform :as mt]))
@@ -9,7 +10,7 @@
 (defn create-workspace-data-js
   "Create workspace data with Malli defaults, optionally overriding fields"
   [& [overrides]]
-  (-> (m/decode schema/WorkspaceSyncData
+  (-> (m/decode codec/WorkspaceSyncData
                 {:workspace {:name "Test Workspace"}}
                 mt/default-value-transformer)
       (merge overrides)
@@ -84,4 +85,3 @@
     (with-console-error-silenced
       (let [effects (workspace/load-error {} (js/Error. "Test error"))]
         (is (empty? effects))))))
-

--- a/test/gremllm/renderer/state/system_test.cljs
+++ b/test/gremllm/renderer/state/system_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer [deftest testing is]]
             [gremllm.renderer.state.system :as system]
             [gremllm.schema :as schema]
+            [gremllm.schema.codec :as codec]
             [malli.core :as m]
             [malli.transform :as mt]))
 
@@ -21,9 +22,9 @@
     (is (= (create-secrets {:anthropic "sk-ant-1234"
                             :openai    "sk-proj-5678"
                             :google    "AIza9012"})
-           (schema/secrets-from-ipc {:anthropic-api-key "sk-ant-1234"
-                                     :openai-api-key    "sk-proj-5678"
-                                     :gemini-api-key    "AIza9012"})))))
+           (codec/secrets-from-ipc {:anthropic-api-key "sk-ant-1234"
+                                    :openai-api-key    "sk-proj-5678"
+                                    :gemini-api-key    "AIza9012"})))))
 
 
 (deftest test-system-info-from-ipc
@@ -31,7 +32,7 @@
     (let [ipc-data #js {:encryption-available? true
                         :secrets #js {:anthropic-api-key "sk-ant-1234"
                                       :openai-api-key "sk-proj-5678"}}
-          result (schema/system-info-from-ipc ipc-data)]
+          result (codec/system-info-from-ipc ipc-data)]
       (is (= {:encryption-available? true
               :secrets (create-secrets {:anthropic "sk-ant-1234"
                                         :openai "sk-proj-5678"})}
@@ -42,7 +43,7 @@
                    :secrets {:anthropic-api-key "ngAA"}}]
     (is (= {:encryption-available? true
             :secrets {:anthropic-api-key "ngAA"}}
-           (schema/system-info-to-ipc flat-data)))))
+           (codec/system-info-to-ipc flat-data)))))
 
 (deftest test-has-any-api-key?
   (testing "returns true when at least one provider has a key"
@@ -54,4 +55,3 @@
     (let [state {:system {:secrets (create-secrets {:anthropic nil
                                                     :openai nil})}}]
       (is (false? (system/has-any-api-key? state))))))
-


### PR DESCRIPTION
- Split IPC/ACP codecs into a new gremllm.schema.codec namespace and removed transport adapters from gremllm.schema.
- Updated all call sites and tests to use codec for IPC/JS/ACP transformations.