### PR TITLE
fix(acp): harden Read tool-call gating and assert completion checks

### DIFF
--- a/src/gremllm/renderer/actions/acp.cljs
+++ b/src/gremllm/renderer/actions/acp.cljs
@@ -42,7 +42,8 @@
    or diff effects for tool-call-updates with diffs."
   [_state update message-id]
   (cond
-    (codec/read-tool-response? update)
+    (and (codec/tool-response-reads? update)
+         (codec/read-tool-response? update))
     (start-response :tool-use (codec/acp-read-display-label update) message-id)
 
     (codec/tool-response-has-diffs? update)

--- a/src/gremllm/renderer/actions/acp.cljs
+++ b/src/gremllm/renderer/actions/acp.cljs
@@ -42,8 +42,8 @@
    or diff effects for tool-call-updates with diffs."
   [_state update message-id]
   (cond
-    (and (codec/tool-response-reads? update)
-         (codec/read-tool-response? update))
+    (and (codec/tool-response-read-event? update)
+         (codec/tool-response-read-with-file-metadata? update))
     (start-response :tool-use (codec/acp-read-display-label update) message-id)
 
     (codec/tool-response-has-diffs? update)

--- a/src/gremllm/schema/codec.cljs
+++ b/src/gremllm/schema/codec.cljs
@@ -129,13 +129,13 @@
     (let [diffs (filterv #(= "diff" (:type %)) content)]
       (when (seq diffs) diffs))))
 
-(defn tool-response-reads?
+(defn tool-response-read-event?
   "True when a tool-call-update is a Read response event."
   [{:keys [session-update] :as update}]
   (and (= :tool-call-update session-update)
        (= "Read" (get-in update [:meta :claude-code :tool-name]))))
 
-(defn read-tool-response?
+(defn tool-response-read-with-file-metadata?
   "True when a Read tool-call-update carries tool-response file metadata."
   [{:keys [session-update] :as update}]
   (and (= :tool-call-update session-update)

--- a/src/gremllm/schema/codec.cljs
+++ b/src/gremllm/schema/codec.cljs
@@ -129,10 +129,17 @@
     (let [diffs (filterv #(= "diff" (:type %)) content)]
       (when (seq diffs) diffs))))
 
+(defn tool-response-reads?
+  "True when a tool-call-update is a Read response event."
+  [{:keys [session-update] :as update}]
+  (and (= :tool-call-update session-update)
+       (= "Read" (get-in update [:meta :claude-code :tool-name]))))
+
 (defn read-tool-response?
-  "True when a tool-call-update carries Read tool-response metadata."
-  [update]
-  (some? (get-in update [:meta :claude-code :tool-response :file])))
+  "True when a Read tool-call-update carries tool-response file metadata."
+  [{:keys [session-update] :as update}]
+  (and (= :tool-call-update session-update)
+       (some? (get-in update [:meta :claude-code :tool-response :file]))))
 
 (defn tool-response-has-diffs?
   "True when a tool-call-update contains diff content.

--- a/test/gremllm/main/effects/acp_integration_test.cljs
+++ b/test/gremllm/main/effects/acp_integration_test.cljs
@@ -14,6 +14,9 @@
     (pprint/pprint update))
   (println "--- End Updates ---"))
 
+(defn- updates [captured]
+  (map :update @captured))
+
 (deftest test-live-acp-happy-path
   (testing "initialize, create session, prompt, and receive updates"
     (async done
@@ -30,8 +33,7 @@
                      (is (= "end_turn" (.-stopReason result)))
                      (is (pos? (count @captured)))
                      (print-updates @captured)
-                     (let [response (->> @captured
-                                         (map :update)
+                     (let [response (->> (updates captured)
                                          (filter #(= :agent-message-chunk (:session-update %)))
                                          (map codec/acp-update-text)
                                          (apply str))]
@@ -43,57 +45,63 @@
                         (acp/shutdown)
                         (done))))))))
 
+(defn- tool-ids [pred updates]
+  (->> updates (filter pred) (map :tool-call-id) set))
+
+(defn- tool-statuses [ids updates]
+  (let [by-id (->> updates
+                   (filter #(= :tool-call-update (:session-update %)))
+                   (group-by :tool-call-id))]
+    (map (fn [id] (some codec/tool-call-update-status (get by-id id))) ids)))
+
+(defn- assert-diffs-target [updates doc-path]
+  (let [diffs (->> updates
+                   (filter codec/tool-response-has-diffs?)
+                   (mapcat codec/tool-response-diffs))]
+    (is (every? #(= doc-path (:path %)) diffs)
+        "All diffs should target the linked document")))
+
+(defn- assert-tools-completed [updates]
+  (let [read-ids (tool-ids codec/tool-response-read-event? updates)
+        diff-ids (tool-ids codec/tool-response-has-diffs? updates)]
+    (is (pos? (count read-ids))
+        "Expected at least one Read tool-call-update event")
+    (is (every? #(= "completed" %) (tool-statuses read-ids updates))
+        "All Read tool calls should succeed")
+    (is (pos? (count diff-ids))
+        "Expected at least one diff from tool-call-update")
+    (is (every? #(= "completed" %) (tool-statuses diff-ids updates))
+        "All diff-producing tool calls should succeed")))
+
 (deftest test-live-document-first-edit
   (testing "resource_link prompt: agent reads doc, proposes diff, file unchanged"
     (async done
-      (let [store    (atom {})
-            captured (atom [])
-            cwd      (.cwd js/process)
-            doc-path (path/resolve "resources/gremllm-launch-log.md")]
+      (let [store         (atom {})
+            captured      (atom [])
+            content-before (atom nil)
+            cwd           (.cwd js/process)
+            doc-path      (path/resolve "resources/gremllm-launch-log.md")]
         (-> (.readFile fsp doc-path "utf8")
-            (.then (fn [content-before]
-                     (-> (acp/initialize (acp/make-session-update-callback store #(swap! captured conj %)) false)
-                         (.then (fn [_] (acp/new-session cwd)))
-                         (.then (fn [session-id]
-                                  (acp/prompt session-id
-                                    (acp-actions/prompt-content-blocks
-                                      "Read the linked document, then propose a single edit: Update the title to something arbitrary. Do not change anything else."
-                                      doc-path))))
-                         (.then (fn [^js result]
-                                  (is (= "end_turn" (.-stopReason result)))
-                                  (print-updates @captured)
-                                  (let [diffs (->> @captured
-                                                   (map :update)
-                                                   (filter codec/tool-response-has-diffs?)
-                                                   (mapcat codec/tool-response-diffs))]
-                                    (is (pos? (count diffs))
-                                        "Expected at least one diff from tool-call-update")
-                                    (is (every? #(= doc-path (:path %)) diffs)
-                                        "All diffs should target the linked document"))
-                                  (let [updates-by-id (->> @captured
-                                                           (map :update)
-                                                           (filter #(= :tool-call-update (:session-update %)))
-                                                           (group-by :tool-call-id))
-                                        read-tool-ids (set (map :tool-call-id
-                                                                 (filter codec/tool-response-read-event?
-                                                                         (map :update @captured))))
-                                        read-statuses (->> read-tool-ids
-                                                           (map (fn [id] (some codec/tool-call-update-status (get updates-by-id id)))))
-                                        diff-tool-ids (set (map :tool-call-id (filter codec/tool-response-has-diffs? (map :update @captured))))
-                                        diff-statuses      (->> diff-tool-ids
-                                                                (map (fn [id] (some codec/tool-call-update-status (get updates-by-id id)))))]
-                                    (is (pos? (count read-tool-ids))
-                                        "Expected at least one Read tool-call-update event")
-                                    (is (every? #(= "completed" %) read-statuses)
-                                        "All Read tool calls should succeed")
-                                    (is (every? #(= "completed" %) diff-statuses)
-                                        "All diff-producing tool calls should succeed"))))
-                         (.then (fn [_] (.readFile fsp doc-path "utf8")))
-                         (.then (fn [content-after]
-                                  (is (= content-before content-after)
-                                      "Document must be unchanged (writeTextFile is a no-op)")))
-                         (.catch (fn [err]
-                                   (is false (str "Document-first edit test failed: " err))))
-                         (.finally (fn []
-                                     (acp/shutdown)
-                                     (done)))))))))))
+            (.then (fn [content] (reset! content-before content)))
+            (.then (fn [_] (acp/initialize (acp/make-session-update-callback store #(swap! captured conj %)) false)))
+            (.then (fn [_] (acp/new-session cwd)))
+            (.then (fn [session-id]
+                     (acp/prompt session-id
+                       (acp-actions/prompt-content-blocks
+                         "Read the linked document, then propose a single edit: Update the title to something arbitrary. Do not change anything else."
+                         doc-path))))
+            (.then (fn [^js result]
+                     (is (= "end_turn" (.-stopReason result)))
+                     (print-updates @captured)
+                     (let [evts (updates captured)]
+                       (assert-diffs-target evts doc-path)
+                       (assert-tools-completed evts))))
+            (.then (fn [_] (.readFile fsp doc-path "utf8")))
+            (.then (fn [content-after]
+                     (is (= @content-before content-after)
+                         "Document must be unchanged (writeTextFile is a no-op)")))
+            (.catch (fn [err]
+                      (is false (str "Document-first edit test failed: " err))))
+            (.finally (fn []
+                        (acp/shutdown)
+                        (done))))))))

--- a/test/gremllm/renderer/actions/acp_test.cljs
+++ b/test/gremllm/renderer/actions/acp_test.cljs
@@ -32,24 +32,21 @@
              effects)))))
 
 (deftest test-handle-tool-event
-  (testing "returns tool-use for tool-call-update with Read tool-response meta"
+  (testing "returns tool-use for Read tool-call-update with file payload"
     (let [effects (acp/handle-tool-event
                     {}
                     {:session-update :tool-call-update
-                     :tool-call-id "toolu_01Ext"
+                     :tool-call-id "toolu_01U3ze1LsKXNhkBj46DM6SPN"
                      :meta {:claude-code {:tool-name "Read"
-                                          :tool-response {:file {:filePath "/path/to/document.md"
-                                                                 :totalLines 37
-                                                                 :numLines 37
-                                                                 :startLine 1}
+                                          :tool-response {:file {:filePath "/Users/paul/Projects/gremllm/resources/gremllm-launch-log.md"
+                                                                 :totalLines 16}
                                                           :type "text"}}}}
-                    456)
-          action (first effects)
-          message (nth action 1)]
-      (is (= :messages.actions/add-to-chat-no-save (first action)))
-      (is (= :tool-use (:type message)))
-      (is (= "Read — document.md (37 lines)" (:text message)))
-      (is (= 456 (:id message)))))
+                    456)]
+      (is (= [[:messages.actions/add-to-chat-no-save
+               {:id 456
+                :type :tool-use
+                :text "Read — gremllm-launch-log.md (16 lines)"}]]
+             effects))))
 
   (testing "dispatches pending diffs from tool-call-update with diff content"
     (let [effects (acp/handle-tool-event


### PR DESCRIPTION
This branch splits Read detection into explicit codec predicates, updates renderer tool-event handling to only emit Read tool-use messages for Read tool-call updates with file metadata, and refactors ACP tests with shared helpers.
It prevents non-Read or metadata-incomplete updates from being rendered as Read output and makes document-first assertions easier to follow.
Integration coverage now verifies both Read and diff-producing tool calls appear and reach completed status, trading slightly more test structure for stronger end-to-end guarantees.