### PR TITLE
feat(document): add accept/reject controls for diff blocks

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -255,6 +255,19 @@
             padding: 0.125rem 0.25rem;
             border-radius: 2px;
         }
+
+        .diff-controls {
+            display: flex;
+            justify-content: flex-end;
+            gap: 0.5rem;
+            margin-top: 0.25rem;
+        }
+
+        .diff-controls button {
+            padding: 0.125rem 0.5rem;
+            font-size: 0.75rem;
+            margin-bottom: 0;
+        }
     </style>
 </head>
 

--- a/src/gremllm/renderer/ui/document.cljs
+++ b/src/gremllm/renderer/ui/document.cljs
@@ -7,7 +7,17 @@
         (mapv (fn [{:keys [type content old-text new-text]}]
                 (case type
                   :text       [:span content]
-                  :diff-block [:div.diff-block [:del old-text] [:ins new-text]]))
+                  :diff-block [:div.diff-block
+                               [:del old-text]
+                               [:ins new-text]
+                               [:div.diff-controls
+                                [:button {:on {:click [[:document.actions/accept-diff
+                                                        {:old-text old-text :new-text new-text}]]}}
+                                 "Accept"]
+                                [:button {:class "secondary outline"
+                                          :on {:click [[:document.actions/reject-diff
+                                                        {:old-text old-text :new-text new-text}]]}}
+                                 "Reject"]]]))
               segments)))
 
 (defn render-document [content pending-diffs]


### PR DESCRIPTION
Diff block rendering now includes inline Accept and Reject controls in each pending change block, with matching `diff-controls` styling updates in the renderer and shared stylesheet.
This matters because it introduces explicit user decision points directly at the artifact surface instead of requiring implicit or off-context interactions.
Button actions dispatch `:document.actions/accept-diff` and `:document.actions/reject-diff` events as integration stubs, deferring persistence and application behavior to follow-up work.