### PR TITLE
feat(topic): persist ACP session state and pending diffs per topic

### DIFF
--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -131,11 +131,11 @@
 (nxr/register-action! :document.actions/create-success document/create-success)
 (nxr/register-action! :document.actions/create-error document/create-error)
 (nxr/register-action! :document.actions/set-content document/set-content)
-(nxr/register-action! :document.actions/append-pending-diffs document/append-pending-diffs)
 
 ;; Topic
 
 ;; Register all topic actions
+(nxr/register-action! :topic.actions/append-pending-diffs topic/append-pending-diffs)
 (nxr/register-action! :topic.actions/start-new topic/start-new-topic)
 (nxr/register-action! :topic.actions/set-active topic/set-active)
 (nxr/register-action! :topic.actions/begin-rename topic/begin-rename)

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -187,6 +187,6 @@
 ;; captured at dispatch start, missing topic data saved by earlier effects in the chain.
 (nxr/register-effect! :acp.effects/init-session
   (fn [{:keys [dispatch]} store topic-id]
-    (if-let [existing-acp-session-id (topic-state/get-topic-field @store topic-id :acp-session-id)]
+    (if-let [existing-acp-session-id (topic-state/get-acp-session-id @store topic-id)]
       (dispatch [[:acp.actions/resume-session topic-id existing-acp-session-id]])
       (dispatch [[:acp.actions/new-session topic-id]]))))

--- a/src/gremllm/renderer/actions/acp.cljs
+++ b/src/gremllm/renderer/actions/acp.cljs
@@ -47,7 +47,7 @@
     (start-response :tool-use (codec/acp-read-display-label update) message-id)
 
     (codec/tool-response-has-diffs? update)
-    [[:document.actions/append-pending-diffs (codec/tool-response-diffs update)]]))
+    [[:topic.actions/append-pending-diffs (codec/tool-response-diffs update)]]))
 
 (defn session-update
   "Handles incoming ACP session updates (streaming chunks, errors, etc).

--- a/src/gremllm/renderer/actions/document.cljs
+++ b/src/gremllm/renderer/actions/document.cljs
@@ -16,6 +16,3 @@
 (defn set-content [_state content]
   [[:effects/save document-state/content-path content]])
 
-(defn append-pending-diffs [state diffs]
-  (let [existing (get-in state document-state/pending-diffs-path [])]
-    [[:effects/save document-state/pending-diffs-path (into existing diffs)]]))

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -50,6 +50,11 @@
     (when (seq messages)
       [[:topic.effects/save-topic topic-id]])))
 
+(defn append-pending-diffs [state diffs]
+  (let [topic-id (topic-state/get-active-topic-id state)
+        existing (or (topic-state/get-topic-field state topic-id :pending-diffs) [])]
+    [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing diffs)]]))
+
 (defn set-active
   "Set the active topic and initialize its ACP session."
   [_state topic-id]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -52,7 +52,7 @@
 
 (defn append-pending-diffs [state diffs]
   (let [topic-id (topic-state/get-active-topic-id state)
-        existing (or (topic-state/get-topic-field state topic-id :pending-diffs) [])]
+        existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])]
     [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing diffs)]]))
 
 (defn set-active

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -51,6 +51,7 @@
       [[:topic.effects/save-topic topic-id]])))
 
 (defn append-pending-diffs [state diffs]
+  ;; TODO: incoming diffs should be matched with acp-session-id
   (let [topic-id (topic-state/get-active-topic-id state)
         existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])]
     [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing diffs)]]))
@@ -94,10 +95,10 @@
   (fn [{dispatch :dispatch} store topic-id]
     (if-let [topic (topic-state/get-topic @store topic-id)]
         (dispatch
-       [[:effects/promise
-         {:promise    (.saveTopic js/window.electronAPI (codec/topic-to-ipc topic))
-          :on-success [[:topic.actions/save-success topic-id]]
-          :on-error   [[:topic.actions/save-error topic-id]]}]])
+         [[:effects/promise
+           {:promise    (.saveTopic js/window.electronAPI (codec/topic-to-ipc topic))
+            :on-success [[:topic.actions/save-success topic-id]]
+            :on-error   [[:topic.actions/save-error topic-id]]}]])
       (dispatch [[:topic.actions/save-error topic-id (js/Error. (str "Topic not found: " topic-id))]]))))
 
 ;; TODO: should :topic.effects/save-active-topic be an action?

--- a/src/gremllm/renderer/state/document.cljs
+++ b/src/gremllm/renderer/state/document.cljs
@@ -5,9 +5,3 @@
 (defn get-content [state]
   (get-in state content-path))
 
-;; S4b: Diffs stored as-is from codec output. Shape may evolve when
-;; renderer consumes this for UI display (S5).
-(def pending-diffs-path [:document :pending-diffs])
-
-(defn get-pending-diffs [state]
-  (get-in state pending-diffs-path))

--- a/src/gremllm/renderer/state/topic.cljs
+++ b/src/gremllm/renderer/state/topic.cljs
@@ -28,6 +28,12 @@
 (defn get-topic-field [state topic-id field]
   (get-in state (topic-field-path topic-id field)))
 
+(defn get-pending-diffs [state]
+  (:pending-diffs (get-active-topic state)))
+
+(defn pending-diffs-path [topic-id]
+  (topic-field-path topic-id :pending-diffs))
+
 (defn get-acp-session-id [state topic-id]
   (:acp-session-id (get-topic state topic-id)))
 

--- a/src/gremllm/renderer/state/topic.cljs
+++ b/src/gremllm/renderer/state/topic.cljs
@@ -29,14 +29,16 @@
   (get-in state (topic-field-path topic-id field)))
 
 (defn get-pending-diffs [state]
-  (:pending-diffs (get-active-topic state)))
+  (get-in (get-active-topic state) [:session :pending-diffs]))
 
 (defn pending-diffs-path [topic-id]
-  (topic-field-path topic-id :pending-diffs))
+  (-> topics-path (conj topic-id :session :pending-diffs)))
 
 (defn get-acp-session-id [state topic-id]
-  (:acp-session-id (get-topic state topic-id)))
+  (get-in (get-topic state topic-id) [:session :id]))
 
 (defn acp-session-id-path [topic-id]
-  (topic-field-path topic-id :acp-session-id))
+  ;; TODO: add reverse lookup from acp-session-id to topic-id for correct
+  ;; inbound routing of session updates to the originating topic
+  (-> topics-path (conj topic-id :session :id)))
 

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -19,7 +19,7 @@
   (let [has-any-api-key?      (system-state/has-any-api-key? state)
         workspace             (workspace-state/get-workspace state)
         document-content      (document-state/get-content state)
-        pending-diffs         (document-state/get-pending-diffs state)
+        pending-diffs         (topic-state/get-pending-diffs state)
         active-topic-id       (topic-state/get-active-topic-id state)
         topics-map            (topic-state/get-topics-map state)
         renaming-topic-id     (ui-state/renaming-topic-id state)

--- a/src/gremllm/renderer/ui/document.cljs
+++ b/src/gremllm/renderer/ui/document.cljs
@@ -11,11 +11,11 @@
                                [:del old-text]
                                [:ins new-text]
                                [:div.diff-controls
-                                [:button {:on {:click [[:document.actions/accept-diff
+                                [:button {:on {:click [[:topic.actions/accept-diff
                                                         {:old-text old-text :new-text new-text}]]}}
                                  "Accept"]
                                 [:button {:class "secondary outline"
-                                          :on {:click [[:document.actions/reject-diff
+                                          :on {:click [[:topic.actions/reject-diff
                                                         {:old-text old-text :new-text new-text}]]}}
                                  "Reject"]]]))
               segments)))

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -112,13 +112,21 @@
         random-suffix (-> (js/Math.random) (.toString 36) (.substring 2))]
     (str "topic-" timestamp "-" random-suffix)))
 
+(def PendingDiff
+  [:map
+   [:type [:= "diff"]]
+   [:path :string]
+   [:old-text {:optional true} :string]
+   [:new-text :string]])
+
 (def PersistedTopic
   "Schema for topics as saved to disk"
   [:map
    [:id {:default/fn generate-topic-id} :string]
    [:name {:default "New Topic"} :string]
    [:acp-session-id {:optional true} :string]         ;; TODO: refator to :uuid type
-   [:messages {:default []} [:vector Message]]])
+   [:messages {:default []} [:vector Message]]
+   [:pending-diffs {:default []} [:vector PendingDiff]]])
 
 (def Topic
   "Schema for topics in app state (includes transient fields)"
@@ -150,9 +158,11 @@
 
 (def topic-from-disk
   "Loads and validates a topic from persisted EDN format.
+  Applies defaults for fields added after initial save (e.g. pending-diffs).
   Throws if the topic data is invalid."
-  (m/coercer Topic mt/json-transformer))
+  (m/coercer Topic (mt/transformer mt/default-value-transformer mt/json-transformer)))
 
 (def topic-for-disk
-  "Prepares topic for disk persistence, stripping transient fields. Throws if invalid."
-  (m/coercer PersistedTopic mt/strip-extra-keys-transformer))
+  "Prepares topic for disk persistence, stripping transient fields.
+  Applies defaults for any fields missing from in-memory topic. Throws if invalid."
+  (m/coercer PersistedTopic (mt/transformer mt/default-value-transformer mt/strip-extra-keys-transformer)))

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -119,15 +119,22 @@
    [:old-text {:optional true} :string]
    [:new-text :string]])
 
+(def AcpSession
+  "Session state produced by an ACP agent for a topic."
+  [:map
+   ;; TODO: id should be required
+   [:id {:optional true}         :string]
+   [:pending-diffs {:default []} [:vector PendingDiff]]])
+
 (def PersistedTopic
   "Schema for topics as saved to disk"
   [:map
    [:id {:default/fn generate-topic-id} :string]
-   [:name {:default "New Topic"} :string]
-   [:acp-session-id {:optional true} :string]         ;; TODO: refator to :uuid type
-   [:messages {:default []} [:vector Message]]
-   [:pending-diffs {:default []} [:vector PendingDiff]]])
+   [:name {:default "New Topic"}        :string]
+   [:session {:default {}}              AcpSession]
+   [:messages {:default []}             [:vector Message]]])
 
+;; TODO: Pivot domain model -- Topic should be Session.
 (def Topic
   "Schema for topics in app state (includes transient fields)"
   (mu/merge
@@ -156,11 +163,24 @@
   [name]
   {:name name})
 
-(def topic-from-disk
-  "Loads and validates a topic from persisted EDN format.
-  Applies defaults for fields added after initial save (e.g. pending-diffs).
-  Throws if the topic data is invalid."
+(defn- migrate-flat-topic
+  "Migrates topics saved with flat {:acp-session-id X :pending-diffs Y} fields
+   to the nested {:session {:id X :pending-diffs Y}} shape."
+  [topic]
+  (cond-> (dissoc topic :acp-session-id :pending-diffs)
+    (:acp-session-id topic)            (assoc-in [:session :id] (:acp-session-id topic))
+    (contains? topic :pending-diffs)   (assoc-in [:session :pending-diffs] (:pending-diffs topic))))
+
+(def ^:private topic-coercer
   (m/coercer Topic (mt/transformer mt/default-value-transformer mt/json-transformer)))
+
+(defn topic-from-disk
+  "Loads and validates a topic from persisted EDN format.
+  Applies defaults for fields added after initial save.
+  Migrates flat {:acp-session-id X :pending-diffs Y} to nested {:session {...}} format.
+  Throws if the topic data is invalid."
+  [topic]
+  (-> topic migrate-flat-topic topic-coercer))
 
 (def topic-for-disk
   "Prepares topic for disk persistence, stripping transient fields.

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -163,24 +163,10 @@
   [name]
   {:name name})
 
-(defn- migrate-flat-topic
-  "Migrates topics saved with flat {:acp-session-id X :pending-diffs Y} fields
-   to the nested {:session {:id X :pending-diffs Y}} shape."
-  [topic]
-  (cond-> (dissoc topic :acp-session-id :pending-diffs)
-    (:acp-session-id topic)            (assoc-in [:session :id] (:acp-session-id topic))
-    (contains? topic :pending-diffs)   (assoc-in [:session :pending-diffs] (:pending-diffs topic))))
-
-(def ^:private topic-coercer
+(def topic-from-disk
+  "Loads and validates a topic from persisted EDN format. Applies defaults for fields added after
+  initial save. Throws if the topic data is invalid."
   (m/coercer Topic (mt/transformer mt/default-value-transformer mt/json-transformer)))
-
-(defn topic-from-disk
-  "Loads and validates a topic from persisted EDN format.
-  Applies defaults for fields added after initial save.
-  Migrates flat {:acp-session-id X :pending-diffs Y} to nested {:session {...}} format.
-  Throws if the topic data is invalid."
-  [topic]
-  (-> topic migrate-flat-topic topic-coercer))
 
 (def topic-for-disk
   "Prepares topic for disk persistence, stripping transient fields.

--- a/test/gremllm/main/actions/topic_test.cljs
+++ b/test/gremllm/main/actions/topic_test.cljs
@@ -8,12 +8,12 @@
     (let [topic {:id "topic-123"
                  :name "Test Topic"
                  :messages []
-                 :pending-diffs []}
+                 :session {:pending-diffs []}}
           topics-dir "/test/dir"
           plan (topic/topic->save-plan topic topics-dir)]
       (is (= topics-dir (:dir plan)))
       (is (= "/test/dir/topic-123.edn" (:filepath plan)))
-      (is (= {:id "topic-123" :name "Test Topic" :messages [] :pending-diffs []}
+      (is (= {:id "topic-123" :name "Test Topic" :messages [] :session {:pending-diffs []}}
              (edn/read-string (:content plan))))))
 
   (testing "strips transient fields before saving"
@@ -27,6 +27,6 @@
       (is (= {:id "topic-123"
               :name "Test Topic"
               :messages []
-              :pending-diffs []}
+              :session {:pending-diffs []}}
              (edn/read-string (:content plan)))))))
 

--- a/test/gremllm/main/actions/topic_test.cljs
+++ b/test/gremllm/main/actions/topic_test.cljs
@@ -7,13 +7,14 @@
   (testing "creates correct save plan structure"
     (let [topic {:id "topic-123"
                  :name "Test Topic"
-                 :messages []}
+                 :messages []
+                 :pending-diffs []}
           topics-dir "/test/dir"
           plan (topic/topic->save-plan topic topics-dir)]
-      (is (= {:dir      topics-dir
-              :filepath "/test/dir/topic-123.edn"
-              :content  "{:id \"topic-123\", :name \"Test Topic\", :messages []}"}
-             plan))))
+      (is (= topics-dir (:dir plan)))
+      (is (= "/test/dir/topic-123.edn" (:filepath plan)))
+      (is (= {:id "topic-123" :name "Test Topic" :messages [] :pending-diffs []}
+             (edn/read-string (:content plan))))))
 
   (testing "strips transient fields before saving"
     (let [topic {:id "topic-123"
@@ -25,6 +26,7 @@
           plan (topic/topic->save-plan topic "/test/dir")]
       (is (= {:id "topic-123"
               :name "Test Topic"
-              :messages []}
+              :messages []
+              :pending-diffs []}
              (edn/read-string (:content plan)))))))
 

--- a/test/gremllm/main/effects/workspace_test.cljs
+++ b/test/gremllm/main/effects/workspace_test.cljs
@@ -16,7 +16,7 @@
 
 (deftest test-parse-topic-content
   (testing "parses valid topic content"
-    (let [topic {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}
+    (let [topic {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []}}
           content (pr-str topic)
           result (#'workspace/parse-topic-content content "test.edn")]
       (is (= topic result))))
@@ -27,7 +27,7 @@
       (is (nil? (#'workspace/parse-topic-content "not-edn" "bad.edn")))))
 
   (testing "applies schema coercion"
-    (let [topic-without-unsaved {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}
+    (let [topic-without-unsaved {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []}}
           content (pr-str topic-without-unsaved)
           result (#'workspace/parse-topic-content content "test.edn")]
       ;; schema/topic-from-disk should not add :unsaved? key
@@ -42,7 +42,7 @@
                         :model "claude-sonnet-4-5-20250929"
                         :reasoning? true
                         :messages [{:id 1754952440824 :type :user :text "Hello"}]
-                        :pending-diffs []}
+                        :session {:pending-diffs []}}
               filename (str (:id topic) ".edn")
               filepath (io/path-join temp-dir filename)
               _saved-path (workspace/save-topic {:dir temp-dir
@@ -86,8 +86,8 @@
     (with-temp-dir "load-topics"
       (fn [dir]
         ;; Simple test topics with just the essentials
-        (let [topic-1 {:id "topic-1-a" :name "First" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}
-              topic-2 {:id "topic-2-b" :name "Second" :model "claude-sonnet-4-5-20250929" :reasoning? false :messages [] :pending-diffs []}]
+        (let [topic-1 {:id "topic-1-a" :name "First" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []}}
+              topic-2 {:id "topic-2-b" :name "Second" :model "claude-sonnet-4-5-20250929" :reasoning? false :messages [] :session {:pending-diffs []}}]
 
           ;; Write valid topic files
           (write-topic-file dir topic-1)
@@ -104,7 +104,7 @@
   (testing "skips corrupt files and loads valid ones"
     (with-temp-dir "load-with-corrupt"
       (fn [dir]
-        (let [good-topic {:id "topic-111-good" :name "Valid" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}]
+        (let [good-topic {:id "topic-111-good" :name "Valid" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []}}]
           ;; Write one valid and one corrupt file
           (write-topic-file dir good-topic)
           (write-file dir "topic-999-bad.edn" "{:broken")

--- a/test/gremllm/main/effects/workspace_test.cljs
+++ b/test/gremllm/main/effects/workspace_test.cljs
@@ -16,7 +16,7 @@
 
 (deftest test-parse-topic-content
   (testing "parses valid topic content"
-    (let [topic {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages []}
+    (let [topic {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}
           content (pr-str topic)
           result (#'workspace/parse-topic-content content "test.edn")]
       (is (= topic result))))
@@ -27,7 +27,7 @@
       (is (nil? (#'workspace/parse-topic-content "not-edn" "bad.edn")))))
 
   (testing "applies schema coercion"
-    (let [topic-without-unsaved {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages []}
+    (let [topic-without-unsaved {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}
           content (pr-str topic-without-unsaved)
           result (#'workspace/parse-topic-content content "test.edn")]
       ;; schema/topic-from-disk should not add :unsaved? key
@@ -41,7 +41,8 @@
                         :name "Test Topic"
                         :model "claude-sonnet-4-5-20250929"
                         :reasoning? true
-                        :messages [{:id 1754952440824 :type :user :text "Hello"}]}
+                        :messages [{:id 1754952440824 :type :user :text "Hello"}]
+                        :pending-diffs []}
               filename (str (:id topic) ".edn")
               filepath (io/path-join temp-dir filename)
               _saved-path (workspace/save-topic {:dir temp-dir
@@ -85,8 +86,8 @@
     (with-temp-dir "load-topics"
       (fn [dir]
         ;; Simple test topics with just the essentials
-        (let [topic-1 {:id "topic-1-a" :name "First" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages []}
-              topic-2 {:id "topic-2-b" :name "Second" :model "claude-sonnet-4-5-20250929" :reasoning? false :messages []}]
+        (let [topic-1 {:id "topic-1-a" :name "First" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}
+              topic-2 {:id "topic-2-b" :name "Second" :model "claude-sonnet-4-5-20250929" :reasoning? false :messages [] :pending-diffs []}]
 
           ;; Write valid topic files
           (write-topic-file dir topic-1)
@@ -103,7 +104,7 @@
   (testing "skips corrupt files and loads valid ones"
     (with-temp-dir "load-with-corrupt"
       (fn [dir]
-        (let [good-topic {:id "topic-111-good" :name "Valid" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages []}]
+        (let [good-topic {:id "topic-111-good" :name "Valid" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :pending-diffs []}]
           ;; Write one valid and one corrupt file
           (write-topic-file dir good-topic)
           (write-file dir "topic-999-bad.edn" "{:broken")

--- a/test/gremllm/renderer/actions/acp_test.cljs
+++ b/test/gremllm/renderer/actions/acp_test.cljs
@@ -57,7 +57,7 @@
                      :content [{:type "diff" :path "/tmp/test.md"
                                 :old-text "old" :new-text "new"}]}
                     123)]
-      (is (= [[:document.actions/append-pending-diffs
+      (is (= [[:topic.actions/append-pending-diffs
                [{:type "diff" :path "/tmp/test.md"
                  :old-text "old" :new-text "new"}]]]
              effects))))

--- a/test/gremllm/schema_test.cljs
+++ b/test/gremllm/schema_test.cljs
@@ -4,6 +4,35 @@
             [gremllm.schema :as schema]
             [gremllm.schema.codec :as codec]))
 
+(deftest test-topic-from-disk-migration
+  (testing "migrates flat acp-session-id and pending-diffs to nested session"
+    (let [flat-topic {:id "topic-123"
+                      :name "Test"
+                      :messages []
+                      :acp-session-id "abc-123"
+                      :pending-diffs [{:type "diff" :path "/a.md" :new-text "new"}]}
+          result (schema/topic-from-disk flat-topic)]
+      (is (nil? (:acp-session-id result)))
+      (is (nil? (:pending-diffs result)))
+      (is (= "abc-123" (get-in result [:session :id])))
+      (is (= [{:type "diff" :path "/a.md" :new-text "new"}]
+             (get-in result [:session :pending-diffs])))))
+
+  (testing "migrates empty pending-diffs at root to nested session"
+    (let [flat-topic {:id "topic-123" :name "Test" :messages [] :pending-diffs []}
+          result (schema/topic-from-disk flat-topic)]
+      (is (nil? (:pending-diffs result)))
+      (is (= [] (get-in result [:session :pending-diffs])))))
+
+  (testing "passes through topics already in nested format"
+    (let [nested-topic {:id "topic-123"
+                        :name "Test"
+                        :messages []
+                        :session {:id "abc-123" :pending-diffs []}}
+          result (schema/topic-from-disk nested-topic)]
+      (is (= "abc-123" (get-in result [:session :id])))
+      (is (= [] (get-in result [:session :pending-diffs]))))))
+
 (deftest test-provider->api-key-keyword
   (testing "maps Anthropic to anthropic-api-key"
     (is (= :anthropic-api-key (schema/provider->api-key-keyword :anthropic))))

--- a/test/gremllm/schema_test.cljs
+++ b/test/gremllm/schema_test.cljs
@@ -4,35 +4,6 @@
             [gremllm.schema :as schema]
             [gremllm.schema.codec :as codec]))
 
-(deftest test-topic-from-disk-migration
-  (testing "migrates flat acp-session-id and pending-diffs to nested session"
-    (let [flat-topic {:id "topic-123"
-                      :name "Test"
-                      :messages []
-                      :acp-session-id "abc-123"
-                      :pending-diffs [{:type "diff" :path "/a.md" :new-text "new"}]}
-          result (schema/topic-from-disk flat-topic)]
-      (is (nil? (:acp-session-id result)))
-      (is (nil? (:pending-diffs result)))
-      (is (= "abc-123" (get-in result [:session :id])))
-      (is (= [{:type "diff" :path "/a.md" :new-text "new"}]
-             (get-in result [:session :pending-diffs])))))
-
-  (testing "migrates empty pending-diffs at root to nested session"
-    (let [flat-topic {:id "topic-123" :name "Test" :messages [] :pending-diffs []}
-          result (schema/topic-from-disk flat-topic)]
-      (is (nil? (:pending-diffs result)))
-      (is (= [] (get-in result [:session :pending-diffs])))))
-
-  (testing "passes through topics already in nested format"
-    (let [nested-topic {:id "topic-123"
-                        :name "Test"
-                        :messages []
-                        :session {:id "abc-123" :pending-diffs []}}
-          result (schema/topic-from-disk nested-topic)]
-      (is (= "abc-123" (get-in result [:session :id])))
-      (is (= [] (get-in result [:session :pending-diffs]))))))
-
 (deftest test-provider->api-key-keyword
   (testing "maps Anthropic to anthropic-api-key"
     (is (= :anthropic-api-key (schema/provider->api-key-keyword :anthropic))))


### PR DESCRIPTION
This nests ACP session data under each persisted topic, moves pending diffs into topic-scoped renderer state, and rewires ACP/UI flows to append and read diffs through topic actions.
This keeps session ids and pending diffs attached to the topic they belong to so reloads and topic switches restore the correct in-flight state.
The schema includes a backwards-compatible migration path for older flat topic files.