### PR TITLE
feat(excerpt): decouple captured selection from panel geometry

### DIFF
--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -79,23 +79,26 @@
      :bounding-rect   (rect-from-dom rect)
      :client-rects    (mapv rect-from-dom (array-seq (.getClientRects range)))}))
 
-;; Register placeholder for text selection events
+;; Register placeholder for text selection events.
+;; Returns {:selection CapturedSelection :anchor AnchorContext-or-nil}
+;; when a non-collapsed selection exists, nil otherwise.
 (nxr/register-placeholder! :event/text-selection
   (fn [{:replicant/keys [dom-event]}]
-    (let [sel (js/document.getSelection)
+    (let [sel   (js/document.getSelection)
           panel (when dom-event (.. dom-event -target (closest ".document-panel")))]
       (when (and sel (pos? (.-rangeCount sel)) (not (.-isCollapsed sel)))
-        (cond-> {:text          (.toString sel)
-                 :range-count   (.-rangeCount sel)
-                 :anchor-node   (.. sel -anchorNode -nodeName)
-                 :anchor-offset (.-anchorOffset sel)
-                 :focus-node    (.. sel -focusNode -nodeName)
-                 :focus-offset  (.-focusOffset sel)
-                 :range         (range-from-dom (.getRangeAt sel 0))}
-          panel (assoc :mouse-x (.-clientX dom-event)
-                       :mouse-y (.-clientY dom-event)
-                       :panel-rect (rect-from-dom (.getBoundingClientRect panel))
-                       :panel-scroll-top (.-scrollTop panel)))))))
+        (let [selection {:text          (.toString sel)
+                         :range-count   (.-rangeCount sel)
+                         :anchor-node   (.. sel -anchorNode -nodeName)
+                         :anchor-offset (.-anchorOffset sel)
+                         :focus-node    (.. sel -focusNode -nodeName)
+                         :focus-offset  (.-focusOffset sel)
+                         :range         (range-from-dom (.getRangeAt sel 0))}
+              anchor    (when panel
+                          {:panel-rect       (rect-from-dom (.getBoundingClientRect panel))
+                           :panel-scroll-top (.-scrollTop panel)})]
+          {:selection selection
+           :anchor    anchor})))))
 
 ; DOM placeholders
 (nxr/register-placeholder! :dom/element-by-id

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -210,7 +210,6 @@
 
 ;; Excerpt
 (nxr/register-action! :excerpt.actions/capture excerpt/capture)
-(nxr/register-action! :excerpt.actions/compute-popover-position excerpt/compute-popover-position)
 (nxr/register-action! :excerpt.actions/dismiss-popover excerpt/dismiss-popover)
 
 ;; ACP

--- a/src/gremllm/renderer/actions/excerpt.cljs
+++ b/src/gremllm/renderer/actions/excerpt.cljs
@@ -2,25 +2,13 @@
   (:require [gremllm.renderer.state.excerpt :as excerpt-state]
             [gremllm.schema.codec :as codec]))
 
-(defn capture [_state selection-data]
-  (if selection-data
-    (let [coerced (codec/captured-selection-from-dom selection-data)]
+(defn capture [_state composite-data]
+  (if composite-data
+    (let [coerced (codec/captured-selection-from-dom (:selection composite-data))]
       [[:effects/save excerpt-state/captured-path coerced]
-       [:excerpt.actions/compute-popover-position coerced]])
+       [:effects/save excerpt-state/anchor-path (:anchor composite-data)]])
     [[:excerpt.actions/dismiss-popover]]))
-
-(defn compute-popover-position [_state captured-data]
-  (when (and captured-data (:panel-rect captured-data))
-    (let [rects      (get-in captured-data [:range :client-rects])
-          last-rect  (last rects)
-          panel-rect (:panel-rect captured-data)
-          scroll-top (:panel-scroll-top captured-data 0)
-          top        (+ (- (+ (:top last-rect) (:height last-rect))
-                           (:top panel-rect))
-                        scroll-top)
-          left       (- (:left last-rect) (:left panel-rect))]
-      [[:effects/save excerpt-state/popover-path {:top top :left left}]])))
 
 (defn dismiss-popover [_state]
   [[:effects/save excerpt-state/captured-path nil]
-   [:effects/save excerpt-state/popover-path nil]])
+   [:effects/save excerpt-state/anchor-path nil]])

--- a/src/gremllm/renderer/state/excerpt.cljs
+++ b/src/gremllm/renderer/state/excerpt.cljs
@@ -11,11 +11,6 @@
 (defn get-anchor [state]
   (get-in state anchor-path))
 
-(def popover-path [:excerpt :popover])
-
-(defn get-popover [state]
-  (get-in state popover-path))
-
 (defn popover-position
   "Derives popover {top, left} from selection geometry and anchor context.
    Returns nil if either input is missing or anchor lacks panel-rect."

--- a/src/gremllm/renderer/state/excerpt.cljs
+++ b/src/gremllm/renderer/state/excerpt.cljs
@@ -6,7 +6,28 @@
 (defn get-captured [state]
   (get-in state captured-path))
 
+(def anchor-path [:excerpt :anchor])
+
+(defn get-anchor [state]
+  (get-in state anchor-path))
+
 (def popover-path [:excerpt :popover])
 
 (defn get-popover [state]
   (get-in state popover-path))
+
+(defn popover-position
+  "Derives popover {top, left} from selection geometry and anchor context.
+   Returns nil if either input is missing or anchor lacks panel-rect."
+  [captured-selection anchor-context]
+  (when (and captured-selection anchor-context (:panel-rect anchor-context))
+    (let [rects      (get-in captured-selection [:range :client-rects])
+          last-rect  (peek rects)
+          panel-rect (:panel-rect anchor-context)
+          scroll-top (:panel-scroll-top anchor-context)]
+      (when last-rect
+        {:top  (+ (- (+ (:top last-rect) (:height last-rect))
+                     (:top panel-rect))
+                  scroll-top)
+         :left (- (:left last-rect)
+                  (:left panel-rect))}))))

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -25,7 +25,9 @@
         topics-map            (topic-state/get-topics-map state)
         renaming-topic-id     (ui-state/renaming-topic-id state)
         nav-expanded?         (ui-state/nav-expanded? state)
-        popover-pos           (excerpt-state/get-popover state)]
+        captured              (excerpt-state/get-captured state)
+        anchor                (excerpt-state/get-anchor state)
+        popover-pos           (excerpt-state/popover-position captured anchor)]
     [e/app-layout
      ;; Zone 1: Nav strip
      [e/nav-strip {:on {:click [[:ui.actions/toggle-nav]]}}

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -205,8 +205,12 @@
    [:anchor-offset :int]
    [:focus-node :string]
    [:focus-offset :int]
-   [:range SelectionRange]
-   [:mouse-x {:optional true} number?]
-   [:mouse-y {:optional true} number?]
-   [:panel-rect {:optional true} ViewportRect]
-   [:panel-scroll-top {:optional true} number?]])
+   [:range SelectionRange]])
+
+(def AnchorContext
+  "Panel geometry snapshot captured at selection time.
+   Ephemeral — only valid until scroll or resize dismisses the popover.
+   Stored at [:excerpt :anchor]."
+  [:map
+   [:panel-rect ViewportRect]
+   [:panel-scroll-top number?]])

--- a/test/gremllm/renderer/actions/excerpt_test.cljs
+++ b/test/gremllm/renderer/actions/excerpt_test.cljs
@@ -4,76 +4,39 @@
             [gremllm.renderer.state.excerpt :as excerpt-state]
             [gremllm.schema-test :as schema-test]))
 
+;; Anchor context fixture matching AnchorContext schema
+(def anchor-context
+  {:panel-rect {:top 100 :left 50 :width 800 :height 600}
+   :panel-scroll-top 20})
+
+;; Composite input that the :event/text-selection placeholder now produces
+(def composite-selection
+  {:selection schema-test/single-word-selection
+   :anchor anchor-context})
+
 ;; ========================================
 ;; capture
 ;; ========================================
 
 (deftest capture-test
-  (testing "nil selection data - dispatches dismiss-popover"
+  (testing "nil composite - dispatches dismiss-popover"
     (let [result (excerpt/capture {} nil)]
       (is (= [[:excerpt.actions/dismiss-popover]] result))))
 
-  (testing "valid selection data - saves captured data and triggers popover position"
-    (let [result (excerpt/capture {} schema-test/single-word-selection)]
+  (testing "valid composite - saves selection at captured-path and anchor at anchor-path"
+    (let [result (excerpt/capture {} composite-selection)]
       (is (= 2 (count result)))
-      (is (= :effects/save (ffirst result)))
-      (is (= excerpt-state/captured-path (second (first result))))
-      (is (= schema-test/single-word-selection (nth (first result) 2)))
-      (is (= :excerpt.actions/compute-popover-position (first (second result))))
-      (is (= schema-test/single-word-selection (second (second result)))))))
-
-;; ========================================
-;; compute-popover-position
-;; ========================================
-
-(def panel-rect {:top 100 :left 50 :width 800 :height 600})
-(def panel-scroll-top 20)
-
-(def single-rect-captured
-  {:range {:client-rects [{:top 200 :left 150 :height 30 :width 100}]}
-   :panel-rect panel-rect
-   :panel-scroll-top panel-scroll-top})
-
-;; top  = (200 + 30) - 100 + 20 = 150
-;; left = 150 - 50             = 100
-(def expected-single-rect-position {:top 150 :left 100})
-
-(def multi-rect-captured
-  {:range {:client-rects [{:top 100 :left 80 :height 20 :width 200}
-                          {:top 120 :left 80 :height 20 :width 180}
-                          {:top 140 :left 80 :height 20 :width 90}]}
-   :panel-rect panel-rect
-   :panel-scroll-top panel-scroll-top})
-
-;; Uses last rect: top=140, height=20, left=80
-;; top  = (140 + 20) - 100 + 20 = 80
-;; left = 80 - 50               = 30
-(def expected-multi-rect-position {:top 80 :left 30})
-
-(deftest compute-popover-position-test
-  (testing "single client-rect - returns save effect with correct position"
-    (let [result (excerpt/compute-popover-position {} single-rect-captured)]
-      (is (= [[:effects/save excerpt-state/popover-path expected-single-rect-position]]
-             result))))
-
-  (testing "multiple client-rects - uses last rect for positioning"
-    (let [result (excerpt/compute-popover-position {} multi-rect-captured)]
-      (is (= [[:effects/save excerpt-state/popover-path expected-multi-rect-position]]
-             result))))
-
-  (testing "nil captured-data - returns nil (no-op)"
-    (is (nil? (excerpt/compute-popover-position {} nil))))
-
-  (testing "missing panel-rect - returns nil (no-op)"
-    (let [no-panel (dissoc single-rect-captured :panel-rect)]
-      (is (nil? (excerpt/compute-popover-position {} no-panel))))))
+      (is (= [:effects/save excerpt-state/captured-path schema-test/single-word-selection]
+             (first result)))
+      (is (= [:effects/save excerpt-state/anchor-path anchor-context]
+             (second result))))))
 
 ;; ========================================
 ;; dismiss-popover
 ;; ========================================
 
 (deftest dismiss-popover-test
-  (testing "returns save effects clearing the excerpt session state"
+  (testing "clears captured-path and anchor-path"
     (is (= [[:effects/save excerpt-state/captured-path nil]
-            [:effects/save excerpt-state/popover-path nil]]
+            [:effects/save excerpt-state/anchor-path nil]]
            (excerpt/dismiss-popover {})))))

--- a/test/gremllm/renderer/state/excerpt_test.cljs
+++ b/test/gremllm/renderer/state/excerpt_test.cljs
@@ -1,0 +1,37 @@
+(ns gremllm.renderer.state.excerpt-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [gremllm.renderer.state.excerpt :as excerpt-state]))
+
+(def panel-rect {:top 100 :left 50 :width 800 :height 600})
+(def anchor-context {:panel-rect panel-rect :panel-scroll-top 20})
+
+(def single-rect-selection
+  {:range {:client-rects [{:top 200 :left 150 :height 30 :width 100}]}})
+;; top  = (200 + 30) - 100 + 20 = 150
+;; left = 150 - 50             = 100
+
+(def multi-rect-selection
+  {:range {:client-rects [{:top 100 :left 80 :height 20 :width 200}
+                          {:top 120 :left 80 :height 20 :width 180}
+                          {:top 140 :left 80 :height 20 :width 90}]}})
+;; Uses last rect: top=140, height=20, left=80
+;; top  = (140 + 20) - 100 + 20 = 80
+;; left = 80 - 50               = 30
+
+(deftest popover-position-test
+  (testing "single client-rect returns correct position"
+    (is (= {:top 150 :left 100}
+           (excerpt-state/popover-position single-rect-selection anchor-context))))
+
+  (testing "multiple client-rects uses last rect"
+    (is (= {:top 80 :left 30}
+           (excerpt-state/popover-position multi-rect-selection anchor-context))))
+
+  (testing "nil captured-selection returns nil"
+    (is (nil? (excerpt-state/popover-position nil anchor-context))))
+
+  (testing "nil anchor-context returns nil"
+    (is (nil? (excerpt-state/popover-position single-rect-selection nil))))
+
+  (testing "missing panel-rect in anchor returns nil"
+    (is (nil? (excerpt-state/popover-position single-rect-selection {})))))

--- a/test/gremllm/schema_test.cljs
+++ b/test/gremllm/schema_test.cljs
@@ -379,3 +379,16 @@
           (codec/captured-selection-from-dom (dissoc single-word-selection :text))
           false
           (catch :default _ true)))))
+
+(deftest anchor-context-schema-test
+  (testing "valid AnchorContext validates"
+    (is (m/validate schema/AnchorContext
+                    {:panel-rect {:top 100 :left 50 :width 800 :height 600}
+                     :panel-scroll-top 20})))
+
+  (testing "missing panel-rect fails validation"
+    (is (not (m/validate schema/AnchorContext {:panel-scroll-top 20}))))
+
+  (testing "missing panel-scroll-top fails validation"
+    (is (not (m/validate schema/AnchorContext
+                         {:panel-rect {:top 100 :left 50 :width 800 :height 600}})))))


### PR DESCRIPTION
This refactor moves transient panel anchor geometry out of CapturedSelection and derives the excerpt popover position at render time instead of storing a separate popover state path. The capture flow now persists stable selection data plus a short-lived anchor context, which keeps the schema cleaner and makes positioning a pure state derivation backed by focused tests. The tradeoff is that anchor context is intentionally ephemeral and only valid until the selection is dismissed on panel movement.