### PR TITLE
feat(excerpt): wire popover staging into the composer flow

### DIFF
--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -55,6 +55,12 @@
             :replicant/dom-event
             (.preventDefault))))
 
+(nxr/register-effect! :effects/stop-propagation
+  (fn [{:keys [dispatch-data]} _]
+    (some-> dispatch-data
+            :replicant/dom-event
+            (.stopPropagation))))
+
 (defn promise->actions [{:keys [dispatch]} _ {:keys [promise on-success on-error]}]
   (-> promise
       (.then (fn [result]
@@ -195,6 +201,7 @@
 ;; Excerpt
 (nxr/register-action! :excerpt.actions/capture excerpt/capture)
 (nxr/register-action! :excerpt.actions/dismiss-popover excerpt/dismiss-popover)
+(nxr/register-action! :excerpt.actions/stage excerpt/stage)
 
 ;; ACP
 (nxr/register-action! :acp.actions/new-session acp/new-session)

--- a/src/gremllm/renderer/actions/excerpt.cljs
+++ b/src/gremllm/renderer/actions/excerpt.cljs
@@ -10,3 +10,8 @@
 (defn dismiss-popover [_state]
   [[:effects/save excerpt-state/captured-path nil]
    [:effects/save excerpt-state/anchor-path nil]])
+
+(defn stage [state]
+  (when-let [captured (get-in state excerpt-state/captured-path)]
+    [[:staging.actions/stage captured]
+     [:excerpt.actions/dismiss-popover]]))

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -35,7 +35,8 @@
       [:span {:style {:font-size "1.5rem"}} "📁"]]
 
      ;; Zone 2: Document panel
-     [e/document-panel {:on {:scroll [[:excerpt.actions/dismiss-popover]]}}
+     [e/document-panel {:on {:scroll    [[:excerpt.actions/dismiss-popover]]
+                             :mousedown [[:excerpt.actions/dismiss-popover]]}}
       (when nav-expanded?
         [e/nav-overlay
          (topics-ui/render-left-panel-content
@@ -46,15 +47,19 @@
       (document-ui/render-document document-content pending-diffs)
       ;; TODO: not domain obvious... perhaps rename or comment?
       (when popover-pos
-        [:div {:style {:position      "absolute"
-                       :top           (str (:top popover-pos) "px")
-                       :left          (str (:left popover-pos) "px")
-                       :z-index       5
-                       :background    "var(--pico-primary)"
-                       :color         "var(--pico-primary-inverse)"
-                       :padding       "4px 8px"
-                       :border-radius "4px"
-                       :font-size     "0.85rem"}}
+        [:button {:style {:position      "absolute"
+                          :top           (str (:top popover-pos) "px")
+                          :left          (str (:left popover-pos) "px")
+                          :z-index       5
+                          :background    "var(--pico-primary)"
+                          :color         "var(--pico-primary-inverse)"
+                          :padding       "4px 8px"
+                          :border-radius "4px"
+                          :font-size     "0.85rem"
+                          :border        "none"
+                          :cursor        "pointer"}
+                  :on {:mousedown [[:effects/stop-propagation]]
+                       :click     [[:excerpt.actions/stage]]}}
          "Stage"])]
 
      ;; Zone 3: Chat panel


### PR DESCRIPTION
This wires the document selection popover into the existing staged-selection flow. Clicking `Stage` now reads the cached captured selection from renderer state, appends it to the active topic's staged selections, and dismisses the popover without depending on the live DOM selection. Popover dismissal remains document-scoped, which preserves the current selection while the user interacts with chat.