### PR TITLE
Fix staged selection context handoff across IPC and topic switches

### DIFF
--- a/docs/2026-04-15-s8-code-review.md
+++ b/docs/2026-04-15-s8-code-review.md
@@ -1,0 +1,128 @@
+# Code Review: feat/s8-staged-selections-context
+
+**Date:** 2026-04-15
+**Branch:** `feat/s8-staged-selections-context`
+**Commit range:** `6550992..ab17e5e` (15 commits)
+**Reviewer:** Claude Sonnet 4.6 (dispatched via superpowers:code-reviewer)
+**Focus:** Tech design, architecture, and implementation simplicity (Rich Hickey)
+
+## What was implemented
+
+**S8: Staged Selections Become AI Context.** Users highlight text in the document panel, stage those selections as "excerpts", and when they submit a chat message the excerpts are attached as `:context`. They travel to the ACP agent as a structured References section. A compact References row renders on the user's message bubble.
+
+New domain shapes introduced (see `src/gremllm/schema.cljs:146-179`):
+- `BlockRef` — identifies a markdown block by start/end offsets in source
+- `DocumentExcerpt` — `{ :id, :text, :locator { :start BlockRef, :end BlockRef } }`
+- `Message :context` — optional vector of `DocumentExcerpt`s on a user message
+- Structured user message crosses the `acp/prompt` IPC boundary as `{ :text, :context }`
+
+Related docs:
+- Spec: `docs/specs/2026-04-14-s8-staged-selections-ai-context-design.md`
+- Plan: `docs/plans/2026-04-14-Staged-Selections-Become-AI-Context.md`
+- Locator spike findings: `docs/plans/2026-04-14-document-excerpt-locator-spike-findings.md`
+
+---
+
+## Strengths
+
+- Schema-first domain — `BlockRef`, `DocumentExcerpt`, and `Message :context` are plain maps described by malli. No incidental wrapper types.
+- `StagedSelection` → `DocumentExcerpt` cleanly decomplects ephemeral capture from durable reference (different state paths, different lifetimes: `[:excerpt :captured]` vs. persisted topic field).
+- `prompt-content-blocks` (`main/actions/acp.cljs:39-52`) is a pure, inspectable transform from `{:text :context}` → ACP content blocks; directly exercised in tests without mocking.
+- `selection-locator` (`renderer/ui/document/locator.cljs:88-107`) is pure; the imperative DOM reader `selection-locator-from-dom` is separate.
+- `submit-messages` (`renderer/actions/ui.cljs:23-37`) threads one message value to both `add-to-chat` and `send-prompt` — no divergence between in-memory and on-wire shapes.
+
+---
+
+## Issues
+
+### Critical
+
+#### 1. No coercion/validation at the `acp/prompt` IPC boundary
+**File:** `src/gremllm/main/core.cljs:120`
+
+The handler does `(js->clj message :keywordize-keys true)` and passes straight into `prompt-content-blocks`. This violates the project's explicit boundary contract (see `CLAUDE.md` — "Schema validation at every boundary (IPC, disk, HTTP, etc.)"). The pattern already exists in `schema/codec.cljs` for secrets, topics, and workspaces; it is absent here.
+
+**Latent bug:** `:kind` arrives as the string `"paragraph"` from JSON. `block-label` in `main/actions/acp.cljs:6-17` dispatches on keywords (`:heading`, `:paragraph`, ...). Every excerpt silently falls through to the default `(name kind)` branch and yields `"paragraph2"` instead of `"p2"` in the References section. Tests don't expose this because they construct CLJS maps directly, bypassing the `js->clj` path.
+
+**Fix:** Add `user-message-from-ipc` in `src/gremllm/schema/codec.cljs` using `(m/coerce Schema data mt/json-transformer)` — the same pattern as `topic-from-ipc`. Call it in the IPC handler before passing to `prompt-content-blocks`.
+
+---
+
+#### 2. Preload double-wraps `acpPrompt`
+**File:** `resources/public/js/preload.js:41,61`
+
+`acpPrompt` is produced by `createIPCBoundary`, then immediately re-wrapped as:
+```js
+acpPrompt: (sessionId, message) => acpPrompt(sessionId, message)
+```
+This wrapper is a no-op identity. All other `createIPCBoundary` exports (`acpNewSession`, `acpResumeSession`) are exposed directly. The wrapper obscures the context-bridge semantics without adding anything.
+
+**Fix:** Remove the wrapper; expose `acpPrompt` directly like the others.
+
+---
+
+### Important
+
+#### 3. Domain name drift: excerpt / staging / staged-selections
+Three names for one concept:
+- `excerpt` — the schema entity (`DocumentExcerpt`)
+- `staging` — the action namespace (`:staging.actions/*`)
+- `staged-selections` — the persisted field on the topic
+
+Stage/unstage handlers live in `renderer/actions/topic.cljs` but dispatch under `:staging.actions/*`. The capture/build side lives in `renderer/actions/excerpt.cljs`. There is already a `TODO` at `renderer/state/excerpt.cljs:3` hinting at the same tension.
+
+**Recommended decomplection:** Settle on `excerpt` throughout. Rename the persisted topic field to `:excerpts`. Move stage/unstage/clear handlers to `renderer.actions.excerpt` alongside the existing capture logic. Rename the action namespace to `:excerpt.actions/*`.
+
+---
+
+#### 4. `:document.actions/set-content` silently clears all staged excerpts across all topics
+**File:** `src/gremllm/renderer/actions/document.cljs:18-21`
+
+Marked with its own `TODO(design)`. The action's name declares it sets content; the implementation also invalidates excerpts on every topic in the workspace. Two problems:
+
+1. Complects content-mutation with excerpt-invalidation policy under a misleading name.
+2. A workspace reload (which also triggers this action) wipes excerpts even though `DocumentExcerpt` already carries snapshot text and doesn't require the document to stay valid.
+
+**Options:** (a) Rename to `document.actions/replace-content` with an explicit docstring stating the invalidation contract, or (b) drop the clearing behavior — excerpts carry their own snapshot text and can survive reloads.
+
+---
+
+#### 5. `block-label` logic duplicated
+**Files:** `src/gremllm/main/actions/acp.cljs:6-17` and `src/gremllm/renderer/ui/chat.cljs:6-20`
+
+Both implement the same kind→prefix table independently. Adding a new block kind (e.g. `:figure`) requires editing two files and risks inconsistent prompt vs. UI labels.
+
+**Fix:** Extract to `schema/block-ref-short-label` (or `schema.cljs`) as a shared pure function.
+
+---
+
+#### 6. Empty-messages guard treats excerpts as second-class
+**File:** `src/gremllm/renderer/actions/topic.cljs:52`
+
+```clojure
+(when (or (seq messages) (seq staged-selections)) ...)
+```
+
+The guard prevents auto-saving a topic whose only content is staged excerpts. This may be the intended skateboard behavior (don't litter disk with nearly-empty topics), but it's undocumented. One sentence of comment resolves it.
+
+---
+
+### Minor
+
+7. `render-excerpt` uses `pr-str` to quote user text in the ACP prompt body (`main/actions/acp.cljs:30-31`) — leaks Clojure quoting conventions into the agent prompt. Consider Markdown fences or plain indented lines.
+
+8. `generate-message-id` returns `js/Date.now` (`schema.cljs:25-28`) — two calls in the same millisecond collide. Pre-existing issue, but `streaming-chunk-effects` now also generates IDs per chunk in the same tick.
+
+9. `AcpSession` has a `TODO: id should be required` (`schema.cljs:206`). Cleanup candidate, especially if you rename `:staged-selections` per issue #3.
+
+10. `locator-label` appends byte offsets (`p2 offset 4-25`) that duplicate info already present in the quoted text returned by `render-excerpt`. The label is advisory; consider omitting the offsets.
+
+---
+
+## Overall assessment
+
+**Not mergeable as-is.** Fix issue #1 before merge — it is the exact trust-boundary lapse the project's own standards describe, and it conceals a live `:kind` keywordization bug that tests do not catch. Issue #2 is a one-liner to clean up in the same pass.
+
+Issues #3 and #4 are structural concerns most likely to cause friction in Bicycle-stage work (specialized agents, managed context). Recommended: address them in a follow-up commit on this branch before merging rather than deferring to the next milestone.
+
+The overall shape — a single `DocumentExcerpt` value flowing document panel → topic state → user message → ACP prompt → chat render — is a clean decomplection win.

--- a/docs/2026-04-15-s8-code-review.md
+++ b/docs/2026-04-15-s8-code-review.md
@@ -48,7 +48,7 @@ The handler does `(js->clj message :keywordize-keys true)` and passes straight i
 
 ---
 
-#### 2. Staging cleanup races on topic switch during in-flight prompt
+#### [FIXED] 2. Staging cleanup races on topic switch during in-flight prompt
 **Files:** `src/gremllm/renderer/actions/acp.cljs:99-112`, `src/gremllm/renderer/actions/topic.cljs:77-82`
 
 `send-prompt` captures the originating `topic-id` from the active topic at send time, but `[:staging.actions/clear-staged]` in the `on-success` vector does not receive that id. `clear-staged` (`topic.cljs:77`) re-reads `(topic-state/get-active-topic-id state)` at resolve time, so it clears whichever topic is active when the promise resolves — not the originating one. `mark-active-unsaved` in that chain (`topic.cljs:41-43`) has the same problem.

--- a/docs/2026-04-15-s8-code-review.md
+++ b/docs/2026-04-15-s8-code-review.md
@@ -48,7 +48,18 @@ The handler does `(js->clj message :keywordize-keys true)` and passes straight i
 
 ---
 
-#### 2. Preload double-wraps `acpPrompt`
+#### 2. Staging cleanup races on topic switch during in-flight prompt
+**Files:** `src/gremllm/renderer/actions/acp.cljs:99-112`, `src/gremllm/renderer/actions/topic.cljs:77-82`
+
+`send-prompt` captures the originating `topic-id` from the active topic at send time, but `[:staging.actions/clear-staged]` in the `on-success` vector does not receive that id. `clear-staged` (`topic.cljs:77`) re-reads `(topic-state/get-active-topic-id state)` at resolve time, so it clears whichever topic is active when the promise resolves — not the originating one. `mark-active-unsaved` in that chain (`topic.cljs:41-43`) has the same problem.
+
+**Behavior:** if the user switches topics while ACP is in flight, the newly-active topic's staged selections are wiped and auto-saved, while the originating topic retains its stale staged selections.
+
+**Fix:** make `clear-staged` accept an explicit `topic-id` argument; dispatch it from `send-prompt` with the captured `topic-id`. Replace `[:staging.actions/clear-staged]` with `[:staging.actions/clear-staged topic-id]` and replace `mark-active-unsaved` with `mark-unsaved topic-id` in the success chain. Add a test that flips `:active-topic-id` before the promise resolves.
+
+---
+
+#### 3. Preload double-wraps `acpPrompt`
 **File:** `resources/public/js/preload.js:41,61`
 
 `acpPrompt` is produced by `createIPCBoundary`, then immediately re-wrapped as:
@@ -63,7 +74,7 @@ This wrapper is a no-op identity. All other `createIPCBoundary` exports (`acpNew
 
 ### Important
 
-#### 3. Domain name drift: excerpt / staging / staged-selections
+#### 4. Domain name drift: excerpt / staging / staged-selections
 Three names for one concept:
 - `excerpt` — the schema entity (`DocumentExcerpt`)
 - `staging` — the action namespace (`:staging.actions/*`)
@@ -75,7 +86,7 @@ Stage/unstage handlers live in `renderer/actions/topic.cljs` but dispatch under 
 
 ---
 
-#### 4. `:document.actions/set-content` silently clears all staged excerpts across all topics
+#### 5. `:document.actions/set-content` silently clears all staged excerpts across all topics
 **File:** `src/gremllm/renderer/actions/document.cljs:18-21`
 
 Marked with its own `TODO(design)`. The action's name declares it sets content; the implementation also invalidates excerpts on every topic in the workspace. Two problems:
@@ -85,9 +96,11 @@ Marked with its own `TODO(design)`. The action's name declares it sets content; 
 
 **Options:** (a) Rename to `document.actions/replace-content` with an explicit docstring stating the invalidation contract, or (b) drop the clearing behavior — excerpts carry their own snapshot text and can survive reloads.
 
+**Note on option (a):** `clear-staged-across-topics` (`topic.cljs:84-87`) only emits `[:effects/save … []]` per topic — no `mark-unsaved`, no `auto-save`. The clear is in-memory-only. A workspace reload re-hydrates topics from disk, resurrecting excerpts that were supposedly invalidated. Option (a) is incomplete unless each cleared topic is also marked unsaved and auto-saved. This is an additional argument for option (b).
+
 ---
 
-#### 5. `block-label` logic duplicated
+#### 6. `block-label` logic duplicated
 **Files:** `src/gremllm/main/actions/acp.cljs:6-17` and `src/gremllm/renderer/ui/chat.cljs:6-20`
 
 Both implement the same kind→prefix table independently. Adding a new block kind (e.g. `:figure`) requires editing two files and risks inconsistent prompt vs. UI labels.
@@ -96,7 +109,7 @@ Both implement the same kind→prefix table independently. Adding a new block ki
 
 ---
 
-#### 6. Empty-messages guard treats excerpts as second-class
+#### 7. Empty-messages guard treats excerpts as second-class
 **File:** `src/gremllm/renderer/actions/topic.cljs:52`
 
 ```clojure
@@ -107,22 +120,46 @@ The guard prevents auto-saving a topic whose only content is staged excerpts. Th
 
 ---
 
+#### 8. Locator failure is not fail-closed
+**Files:** `src/gremllm/renderer/actions.cljs:86`, `src/gremllm/renderer/ui/document/locator.cljs:121-139`, `src/gremllm/renderer/actions/excerpt.cljs:24-30`, `src/gremllm/schema.cljs:163-169`
+
+`selection-locator-from-dom` returns `nil` when either selection endpoint lacks a block-selector ancestor. The call site (`renderer/actions.cljs:86`) passes that `nil` as `locator-hints`. `excerpt/stage` then hands it directly to `capture->excerpt`, which sets `:locator nil` on the resulting `DocumentExcerpt`.
+
+`DocumentExcerpt.locator` is a **required** map in the schema (`schema.cljs:163-169`). The staging action succeeds; the schema violation surfaces later when the next auto-save runs `topic-to-ipc` → `m/coerce schema/Topic`, which throws. Net effect: the user stages an excerpt successfully, then the background save blows up silently.
+
+**Fix:** refuse to stage when `locator-hints` is nil — return `[[:excerpt.actions/dismiss-popover]]` (optionally with a warning in state). This matches the "auditable first-class context" intent better than staging an invalid excerpt. Alternatively, extend the schema to allow a `:no-locator` shape and propagate that through the pipeline.
+
+---
+
+#### 9. Same-block offsets use first-text-match, not the actual selection position
+**File:** `src/gremllm/renderer/ui/document/locator.cljs:99-107`
+
+When start and end blocks are the same, `selection-locator` computes offsets via `(.indexOf block-text selected-text)`. This returns the **first** occurrence of the selected text in the block, regardless of which occurrence the user highlighted.
+
+For blocks with repeated substrings (common in lists and tables), the stored `:start-offset` / `:end-offset` is wrong, and the ACP prompt's `offset 4-25` label actively misleads the agent.
+
+**Fix options:** (a) drop offsets entirely — the quoted text in `render-excerpt` already identifies the content, making offsets redundant and potentially wrong; (b) derive block-relative offsets from the DOM Range in `selection-locator-from-dom` rather than via post-hoc string search.
+
+---
+
 ### Minor
 
-7. `render-excerpt` uses `pr-str` to quote user text in the ACP prompt body (`main/actions/acp.cljs:30-31`) — leaks Clojure quoting conventions into the agent prompt. Consider Markdown fences or plain indented lines.
+9. `render-excerpt` uses `pr-str` to quote user text in the ACP prompt body (`main/actions/acp.cljs:30-31`) — leaks Clojure quoting conventions into the agent prompt. Consider Markdown fences or plain indented lines.
 
-8. `generate-message-id` returns `js/Date.now` (`schema.cljs:25-28`) — two calls in the same millisecond collide. Pre-existing issue, but `streaming-chunk-effects` now also generates IDs per chunk in the same tick.
+10. `generate-message-id` returns `js/Date.now` (`schema.cljs:25-28`) — two calls in the same millisecond collide. Pre-existing issue, but `streaming-chunk-effects` now also generates IDs per chunk in the same tick.
 
-9. `AcpSession` has a `TODO: id should be required` (`schema.cljs:206`). Cleanup candidate, especially if you rename `:staged-selections` per issue #3.
-
-10. `locator-label` appends byte offsets (`p2 offset 4-25`) that duplicate info already present in the quoted text returned by `render-excerpt`. The label is advisory; consider omitting the offsets.
+11. `AcpSession` has a `TODO: id should be required` (`schema.cljs:206`). Cleanup candidate, especially if you rename `:staged-selections` per issue #4.
 
 ---
 
 ## Overall assessment
 
-**Not mergeable as-is.** Fix issue #1 before merge — it is the exact trust-boundary lapse the project's own standards describe, and it conceals a live `:kind` keywordization bug that tests do not catch. Issue #2 is a one-liner to clean up in the same pass.
+**Not mergeable as-is.** There are three critical issues:
 
-Issues #3 and #4 are structural concerns most likely to cause friction in Bicycle-stage work (specialized agents, managed context). Recommended: address them in a follow-up commit on this branch before merging rather than deferring to the next milestone.
+1. **IPC boundary lacks coercion** (issue #1) — violates the project's explicit trust-boundary contract and conceals a live `:kind` keywordization bug that tests do not catch. Issue #3 (preload double-wrap) is a one-liner to clean up in the same pass.
+2. **Staging cleanup races on topic switch** (issue #2) — `clear-staged` uses the active topic at resolve time, not the originating topic at send time. A realistic user action (switching topics during a slow ACP call) silently corrupts the wrong topic's staged selections.
+3. **Nil locator stages invalid durable state** (issue #8) — a selection outside a block-selector element produces a nil locator, stages successfully, then throws at the next auto-save.
+
+Issues #4, #5, and #9 are structural concerns most likely to cause friction in Bicycle-stage work (specialized agents, managed context). Recommended: address them in a follow-up commit on this branch before merging rather than deferring to the next milestone.
 
 The overall shape — a single `DocumentExcerpt` value flowing document panel → topic state → user message → ACP prompt → chat render — is a clean decomplection win.

--- a/docs/2026-04-15-s8-code-review.md
+++ b/docs/2026-04-15-s8-code-review.md
@@ -37,7 +37,7 @@ Related docs:
 
 ### Critical
 
-#### 1. No coercion/validation at the `acp/prompt` IPC boundary
+#### [FIXED] 1. No coercion/validation at the `acp/prompt` IPC boundary
 **File:** `src/gremllm/main/core.cljs:120`
 
 The handler does `(js->clj message :keywordize-keys true)` and passes straight into `prompt-content-blocks`. This violates the project's explicit boundary contract (see `CLAUDE.md` — "Schema validation at every boundary (IPC, disk, HTTP, etc.)"). The pattern already exists in `schema/codec.cljs` for secrets, topics, and workspaces; it is absent here.

--- a/docs/2026-04-15-s8-code-review.md
+++ b/docs/2026-04-15-s8-code-review.md
@@ -59,7 +59,7 @@ The handler does `(js->clj message :keywordize-keys true)` and passes straight i
 
 ---
 
-#### 3. Preload double-wraps `acpPrompt`
+#### [FIXED] 3. Preload double-wraps `acpPrompt`
 **File:** `resources/public/js/preload.js:41,61`
 
 `acpPrompt` is produced by `createIPCBoundary`, then immediately re-wrapped as:

--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -38,6 +38,12 @@ const createIPCBoundary = (channel) => {
 
 const acpNewSession = createIPCBoundary("acp/new-session");
 const acpResumeSession = createIPCBoundary("acp/resume-session");
+/**
+ * Send a structured user message to an existing ACP session.
+ * @param {string} sessionId
+ * @param {object} message
+ * @returns {Promise<{stopReason: string}>}
+ */
 const acpPrompt = createIPCBoundary("acp/prompt");
 
 contextBridge.exposeInMainWorld("electronAPI", {
@@ -58,5 +64,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	// ACP API
 	acpNewSession,
 	acpResumeSession,
-	acpPrompt: (sessionId, message) => acpPrompt(sessionId, message),
+	acpPrompt,
 });

--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -36,13 +36,21 @@ const createIPCBoundary = (channel) => {
 	};
 };
 
-const acpNewSession = createIPCBoundary("acp/new-session");
-const acpResumeSession = createIPCBoundary("acp/resume-session");
 /**
- * Send a structured user message to an existing ACP session.
- * @param {string} sessionId
- * @param {object} message
- * @returns {Promise<{stopReason: string}>}
+ * @returns {Promise<string>} New ACP session ID.
+ */
+const acpNewSession = createIPCBoundary("acp/new-session");
+
+/**
+ * @param {string} sessionId Stored ACP session ID.
+ * @returns {Promise<string>} Resumed ACP session ID.
+ */
+const acpResumeSession = createIPCBoundary("acp/resume-session");
+
+/**
+ * @param {string} sessionId Topic ACP session ID.
+ * @param {object} message Structured user message.
+ * @returns {Promise<{stopReason: string}>} ACP prompt result.
  */
 const acpPrompt = createIPCBoundary("acp/prompt");
 

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -122,7 +122,7 @@
                               :ipc-correlation-id ipc-correlation-id
                               :channel "acp/prompt"}
                        [[:acp.effects/send-prompt
-                         acp-session-id (js->clj message :keywordize-keys true)
+                         acp-session-id (codec/user-message-from-ipc message)
                          (state/get-workspace-dir @store)]]))))
 
 (defn- setup-system-resources [store]

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -199,6 +199,7 @@
 ;; Staging
 (nxr/register-action! :staging.actions/stage topic/stage)
 (nxr/register-action! :staging.actions/unstage topic/unstage)
+(nxr/register-action! :staging.actions/clear-active-staged topic/clear-active-staged)
 (nxr/register-action! :staging.actions/clear-staged topic/clear-staged)
 (nxr/register-action! :staging.actions/clear-staged-across-topics topic/clear-staged-across-topics)
 

--- a/src/gremllm/renderer/actions/acp.cljs
+++ b/src/gremllm/renderer/actions/acp.cljs
@@ -106,7 +106,6 @@
                                  acp-session-id
                                  (clj->js message))
          :on-success [[:loading.actions/set-loading? topic-id false]
-                      [:staging.actions/clear-staged]
-                      [:topic.effects/auto-save topic-id]]
+                      [:staging.actions/clear-staged topic-id]]
          :on-error   [[:loading.actions/set-loading? topic-id false]]}]]
       (js/console.error "[ACP] No session for prompt"))))

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -74,11 +74,17 @@
      [:topic.actions/mark-active-unsaved]
      [:topic.effects/auto-save topic-id]]))
 
-(defn clear-staged [state]
+(defn clear-active-staged [state]
   (let [topic-id (topic-state/get-active-topic-id state)
         path     (topic-state/staged-selections-path topic-id)]
     [[:effects/save path []]
      [:topic.actions/mark-active-unsaved]
+     [:topic.effects/auto-save topic-id]]))
+
+(defn clear-staged [_state topic-id]
+  (let [path (topic-state/staged-selections-path topic-id)]
+    [[:effects/save path []]
+     [:topic.actions/mark-unsaved topic-id]
      [:topic.effects/auto-save topic-id]]))
 
 (defn clear-staged-across-topics [state]

--- a/src/gremllm/renderer/ui/chat.cljs
+++ b/src/gremllm/renderer/ui/chat.cljs
@@ -95,7 +95,7 @@
          "✕"]])
      (when (> (count staged-selections) 1)
        [:button {:type "button"
-                 :on {:click [[:staging.actions/clear-staged]]}}
+                 :on {:click [[:staging.actions/clear-active-staged]]}}
         "Clear all"])]))
 
 (defn- render-attachment-indicator [pending-attachments]

--- a/src/gremllm/schema/codec.cljs
+++ b/src/gremllm/schema/codec.cljs
@@ -90,6 +90,14 @@
     (js->clj $ :keywordize-keys true)
     (m/coerce schema/Topic $ mt/json-transformer)))
 
+(defn user-message-from-ipc
+  "Transforms structured user message data from IPC into internal Message schema.
+   Throws if invalid."
+  [message-js]
+  (as-> message-js $
+    (js->clj $ :keywordize-keys true)
+    (m/coerce schema/Message $ mt/json-transformer)))
+
 (defn workspace-sync-from-ipc
   "Validates and transforms workspace sync data from IPC. Throws if invalid."
   [workspace-data-js]

--- a/test/gremllm/renderer/actions/acp_test.cljs
+++ b/test/gremllm/renderer/actions/acp_test.cljs
@@ -2,7 +2,8 @@
   (:require [cljs.test :refer [are deftest is testing]]
             [gremllm.schema :as schema]
             [gremllm.schema.codec :as codec]
-            [gremllm.renderer.actions.acp :as acp]))
+            [gremllm.renderer.actions.acp :as acp]
+            [gremllm.schema-test :as schema-test]))
 
 (deftest test-append-to-response
   (testing "appends chunk text to last message in active topic"
@@ -106,22 +107,23 @@
           "window"
           #js {:electronAPI #js {:acpPrompt (fn [_ _ _] (js/Promise.resolve nil))}})
     (try
-      (let [message {:id 1
-                     :type :user
-                     :text "reword these"
-                     :context {:excerpts [{:id "e1"
-                                           :text "x"
-                                           :locator {:document-relative-path "document.md"
-                                                     :start-block {:kind :paragraph
+      (let [message (schema-test/create-message
+                      {:id 1
+                       :type :user
+                       :text "reword these"
+                       :context {:excerpts [{:id "e1"
+                                             :text "x"
+                                             :locator {:document-relative-path "document.md"
+                                                       :start-block {:kind :paragraph
+                                                                     :index 2
+                                                                     :start-line 3
+                                                                     :end-line 3
+                                                                     :block-text-snippet "x"}
+                                                       :end-block {:kind :paragraph
                                                                    :index 2
                                                                    :start-line 3
                                                                    :end-line 3
-                                                                   :block-text-snippet "x"}
-                                                     :end-block {:kind :paragraph
-                                                                 :index 2
-                                                                 :start-line 3
-                                                                 :end-line 3
-                                                                 :block-text-snippet "x"}}}]}}
+                                                                   :block-text-snippet "x"}}}]}})
             state {:active-topic-id "t1"
                    :topics {"t1" {:id "t1" :session {:id "s1"}}}}
             [[_ _ _] promise-effect] (acp/send-prompt state message)

--- a/test/gremllm/renderer/actions/acp_test.cljs
+++ b/test/gremllm/renderer/actions/acp_test.cljs
@@ -129,9 +129,9 @@
             [[_ _ _] promise-effect] (acp/send-prompt state message)
             on-success (get-in promise-effect [1 :on-success])
             on-error (get-in promise-effect [1 :on-error])]
-        (is (some #{[:staging.actions/clear-staged]} on-success)
-            "success clears staged selections")
-        (is (not (some #{[:staging.actions/clear-staged]} on-error))
+        (is (some #{[:staging.actions/clear-staged "t1"]} on-success)
+            "success clears staged selections for the originating topic")
+        (is (not (some #{[:staging.actions/clear-staged "t1"]} on-error))
             "error preserves staged selections"))
       (finally
         (if (nil? old-window)

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -140,15 +140,29 @@
         (is (= [:topic.actions/mark-active-unsaved] (nth actions 1)))
         (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))))
 
-(deftest clear-staged-test
+(deftest clear-active-staged-test
   (let [item sample-excerpt
         state (assoc-in base-state [:topics topic-id :staged-selections] [item])
-        actions (topic/clear-staged state)]
+        actions (topic/clear-active-staged state)]
     (is (= [:effects/save
             (topic-state/staged-selections-path topic-id)
             []]
            (first actions)))
     (is (= [:topic.actions/mark-active-unsaved] (nth actions 1)))
+    (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))
+
+(deftest clear-staged-targets-explicit-topic-test
+  (let [state {:active-topic-id "topic-999"
+               :topics {topic-id {:id topic-id
+                                  :staged-selections [sample-excerpt]}
+                        "topic-999" {:id "topic-999"
+                                     :staged-selections [(assoc sample-excerpt :id "e2")]}}}
+        actions (topic/clear-staged state topic-id)]
+    (is (= [:effects/save
+            (topic-state/staged-selections-path topic-id)
+            []]
+           (first actions)))
+    (is (= [:topic.actions/mark-unsaved topic-id] (nth actions 1)))
     (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))
 
 (deftest auto-save-fires-when-staged-selections-present-with-no-messages-test

--- a/test/gremllm/renderer/ui/chat_test.cljs
+++ b/test/gremllm/renderer/ui/chat_test.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [clojure.walk :as walk]
             [gremllm.renderer.ui.chat :as chat-ui]
+            [gremllm.schema-test :as schema-test]
             [lookup.core :as lookup]))
 
 (deftest render-input-form-test
@@ -63,16 +64,18 @@
                          :block-text-snippet "Body"}}})
 
 (deftest plain-user-message-has-no-references-test
-  (let [hiccup (#'chat-ui/render-message {:id 1 :type :user :text "hello"})]
+  (let [hiccup (#'chat-ui/render-message
+                (schema-test/create-message {:id 1 :type :user :text "hello"}))]
     (is (not (contains-text? hiccup "References")))
     (is (contains-text? hiccup "hello"))))
 
 (deftest user-message-with-same-block-excerpt-renders-compact-pill-test
   (let [hiccup (#'chat-ui/render-message
-                {:id 1
-                 :type :user
-                 :text "reword these"
-                 :context {:excerpts [same-block-excerpt]}})]
+                (schema-test/create-message
+                  {:id 1
+                   :type :user
+                   :text "reword these"
+                   :context {:excerpts [same-block-excerpt]}}))]
     (is (contains-text? hiccup "reword these"))
     (is (contains-text? hiccup "p3"))
     (is (contains-text? hiccup "this is a selection longer than forty c"))
@@ -81,8 +84,9 @@
 
 (deftest user-message-with-cross-block-excerpt-renders-arrow-label-test
   (let [hiccup (#'chat-ui/render-message
-                {:id 1
-                 :type :user
-                 :text "compare"
-                 :context {:excerpts [cross-block-excerpt]}})]
+                (schema-test/create-message
+                  {:id 1
+                   :type :user
+                   :text "compare"
+                   :context {:excerpts [cross-block-excerpt]}}))]
     (is (contains-text? hiccup "h1 -> p2"))))

--- a/test/gremllm/schema/codec_test.cljs
+++ b/test/gremllm/schema/codec_test.cljs
@@ -3,6 +3,31 @@
             [gremllm.schema.codec :as codec]
             [gremllm.schema-test :as schema-test]))
 
+(deftest user-message-from-ipc-test
+  (testing "coerces a JS-shaped user message payload into schema/Message"
+    (let [js-data (clj->js {:id 42
+                            :type :user
+                            :text "reword these"
+                            :context {:excerpts [{:id "e1"
+                                                  :text "launched on a Tuesday"
+                                                  :locator {:document-relative-path "document.md"
+                                                            :start-block {:kind :paragraph
+                                                                          :index 2
+                                                                          :start-line 3
+                                                                          :end-line 3
+                                                                          :block-text-snippet "Our Gremllm launched on a Tuesday."}
+                                                            :end-block {:kind :heading
+                                                                        :index 1
+                                                                        :start-line 1
+                                                                        :end-line 1
+                                                                        :block-text-snippet "Launch Log"}}}]}})
+          result (codec/user-message-from-ipc js-data)]
+      (is (= :user (:type result)))
+      (is (= :paragraph (get-in result [:context :excerpts 0 :locator :start-block :kind])))
+      (is (= :heading (get-in result [:context :excerpts 0 :locator :end-block :kind])))
+      (is (= "launched on a Tuesday"
+             (get-in result [:context :excerpts 0 :text]))))))
+
 (deftest test-acp-read-display-label
   (testing "returns 'Read — filename (N lines)' when tool-response meta present"
     (is (= "Read — document.md (37 lines)"

--- a/test/gremllm/schema/codec_test.cljs
+++ b/test/gremllm/schema/codec_test.cljs
@@ -1,32 +1,39 @@
 (ns gremllm.schema.codec-test
   (:require [cljs.test :refer [deftest is testing]]
+            [gremllm.schema :as schema]
             [gremllm.schema.codec :as codec]
-            [gremllm.schema-test :as schema-test]))
+            [gremllm.schema-test :as schema-test]
+            [malli.core :as m]
+            [malli.transform :as mt]))
+
+(defn create-message
+  "Build a schema/Message fixture from Malli defaults and explicit overrides."
+  [overrides]
+  (merge (m/decode schema/Message {} mt/default-value-transformer)
+         overrides))
 
 (deftest user-message-from-ipc-test
   (testing "coerces a JS-shaped user message payload into schema/Message"
-    (let [js-data (clj->js {:id 42
-                            :type :user
-                            :text "reword these"
-                            :context {:excerpts [{:id "e1"
-                                                  :text "launched on a Tuesday"
-                                                  :locator {:document-relative-path "document.md"
-                                                            :start-block {:kind :paragraph
-                                                                          :index 2
-                                                                          :start-line 3
-                                                                          :end-line 3
-                                                                          :block-text-snippet "Our Gremllm launched on a Tuesday."}
-                                                            :end-block {:kind :heading
-                                                                        :index 1
-                                                                        :start-line 1
-                                                                        :end-line 1
-                                                                        :block-text-snippet "Launch Log"}}}]}})
+    (let [expected-message
+          (create-message {:id 42
+                           :type :user
+                           :text "reword these"
+                           :context {:excerpts [{:id "e1"
+                                                 :text "launched on a Tuesday"
+                                                 :locator {:document-relative-path "document.md"
+                                                           :start-block {:kind :paragraph
+                                                                         :index 2
+                                                                         :start-line 3
+                                                                         :end-line 3
+                                                                         :block-text-snippet "Our Gremllm launched on a Tuesday."}
+                                                           :end-block {:kind :heading
+                                                                       :index 1
+                                                                       :start-line 1
+                                                                       :end-line 1
+                                                                       :block-text-snippet "Launch Log"}}}]}})
+          js-data (clj->js expected-message)
           result (codec/user-message-from-ipc js-data)]
-      (is (= :user (:type result)))
-      (is (= :paragraph (get-in result [:context :excerpts 0 :locator :start-block :kind])))
-      (is (= :heading (get-in result [:context :excerpts 0 :locator :end-block :kind])))
-      (is (= "launched on a Tuesday"
-             (get-in result [:context :excerpts 0 :text]))))))
+      (is (= expected-message result)))))
 
 (deftest test-acp-read-display-label
   (testing "returns 'Read — filename (N lines)' when tool-response meta present"

--- a/test/gremllm/schema/codec_test.cljs
+++ b/test/gremllm/schema/codec_test.cljs
@@ -1,36 +1,27 @@
 (ns gremllm.schema.codec-test
   (:require [cljs.test :refer [deftest is testing]]
-            [gremllm.schema :as schema]
             [gremllm.schema.codec :as codec]
-            [gremllm.schema-test :as schema-test]
-            [malli.core :as m]
-            [malli.transform :as mt]))
-
-(defn create-message
-  "Build a schema/Message fixture from Malli defaults and explicit overrides."
-  [overrides]
-  (merge (m/decode schema/Message {} mt/default-value-transformer)
-         overrides))
+            [gremllm.schema-test :as schema-test]))
 
 (deftest user-message-from-ipc-test
   (testing "coerces a JS-shaped user message payload into schema/Message"
     (let [expected-message
-          (create-message {:id 42
-                           :type :user
-                           :text "reword these"
-                           :context {:excerpts [{:id "e1"
-                                                 :text "launched on a Tuesday"
-                                                 :locator {:document-relative-path "document.md"
-                                                           :start-block {:kind :paragraph
-                                                                         :index 2
-                                                                         :start-line 3
-                                                                         :end-line 3
-                                                                         :block-text-snippet "Our Gremllm launched on a Tuesday."}
-                                                           :end-block {:kind :heading
-                                                                       :index 1
-                                                                       :start-line 1
-                                                                       :end-line 1
-                                                                       :block-text-snippet "Launch Log"}}}]}})
+          (schema-test/create-message {:id 42
+                                       :type :user
+                                       :text "reword these"
+                                       :context {:excerpts [{:id "e1"
+                                                             :text "launched on a Tuesday"
+                                                             :locator {:document-relative-path "document.md"
+                                                                       :start-block {:kind :paragraph
+                                                                                     :index 2
+                                                                                     :start-line 3
+                                                                                     :end-line 3
+                                                                                     :block-text-snippet "Our Gremllm launched on a Tuesday."}
+                                                                       :end-block {:kind :heading
+                                                                                   :index 1
+                                                                                   :start-line 1
+                                                                                   :end-line 1
+                                                                                   :block-text-snippet "Launch Log"}}}]}})
           js-data (clj->js expected-message)
           result (codec/user-message-from-ipc js-data)]
       (is (= expected-message result)))))

--- a/test/gremllm/schema_test.cljs
+++ b/test/gremllm/schema_test.cljs
@@ -1,7 +1,14 @@
 (ns gremllm.schema-test
   (:require [cljs.test :refer [deftest is testing]]
             [gremllm.schema :as schema]
-            [malli.core :as m]))
+            [malli.core :as m]
+            [malli.transform :as mt]))
+
+(defn create-message
+  "Build a schema/Message fixture from Malli defaults and explicit overrides."
+  [overrides]
+  (merge (m/decode schema/Message {} mt/default-value-transformer)
+         overrides))
 
 (deftest test-provider->api-key-keyword
   (testing "maps Anthropic to anthropic-api-key"
@@ -198,13 +205,13 @@
                            :end-offset 11}}]
     (testing "message with excerpt context"
       (is (m/validate schema/Message
-                      {:id 1
-                       :type :user
-                       :text "reword these"
-                       :context {:excerpts [excerpt]}})))
+                      (create-message {:id 1
+                                       :type :user
+                                       :text "reword these"
+                                       :context {:excerpts [excerpt]}}))))
     (testing "message without context still valid"
       (is (m/validate schema/Message
-                      {:id 1 :type :user :text "hello"})))))
+                      (create-message {:id 1 :type :user :text "hello"}))))))
 
 (deftest persisted-topic-staged-selections-are-document-excerpts-test
   (let [excerpt {:id "e1"


### PR DESCRIPTION
This hardens the S8 staged-selections flow by coercing structured user messages at the `acp/prompt` IPC boundary, exposing `acpPrompt` directly in preload, and clearing staged selections for the originating topic instead of whichever topic is active when the ACP request resolves. It also updates the related schema, renderer, and UI tests to use valid message fixtures and cover the topic-switch race. The main tradeoff is a slightly more explicit topic-scoped staging API in the renderer, but it removes a real cross-topic corruption path.