### PR TITLE
refactor(excerpt): rename staged selections to excerpts

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -147,14 +147,14 @@
             resize: none;
         }
 
-        .staged-selections {
+        .excerpt-list {
             display: flex;
             flex-wrap: wrap;
             gap: 0.25rem;
             margin-bottom: 0.5rem;
         }
 
-        .staged-pill {
+        .excerpt-chip {
             display: inline-flex;
             align-items: center;
             gap: 0.25rem;
@@ -165,7 +165,7 @@
             color: var(--pico-muted-color);
         }
 
-        .staged-pill .dismiss {
+        .excerpt-chip .dismiss {
             all: unset;
             cursor: pointer;
             padding: 0 0.125rem;
@@ -282,7 +282,7 @@
             border-radius: 2px;
         }
 
-        ::highlight(staged-excerpt) {
+        ::highlight(excerpt) {
             background-color: color-mix(in srgb, var(--tva-amber) 18%, transparent);
             border-radius: 2px;
         }

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -196,17 +196,14 @@
 (nxr/register-action! :settings.actions/remove-success settings/remove-success)
 (nxr/register-action! :settings.actions/remove-error settings/remove-error)
 
-;; Staging
-(nxr/register-action! :staging.actions/stage topic/stage)
-(nxr/register-action! :staging.actions/unstage topic/unstage)
-(nxr/register-action! :staging.actions/clear-active-staged topic/clear-active-staged)
-(nxr/register-action! :staging.actions/clear-staged topic/clear-staged)
-(nxr/register-action! :staging.actions/clear-staged-across-topics topic/clear-staged-across-topics)
-
 ;; Excerpt
 (nxr/register-action! :excerpt.actions/capture excerpt/capture)
 (nxr/register-action! :excerpt.actions/dismiss-popover excerpt/dismiss-popover)
-(nxr/register-action! :excerpt.actions/stage excerpt/stage)
+(nxr/register-action! :excerpt.actions/add excerpt/add)
+(nxr/register-action! :excerpt.actions/remove excerpt/remove-excerpt)
+(nxr/register-action! :excerpt.actions/clear-active excerpt/clear-active)
+(nxr/register-action! :excerpt.actions/clear excerpt/clear)
+(nxr/register-action! :excerpt.actions/clear-across-topics excerpt/clear-across-topics)
 
 ;; ACP
 (nxr/register-action! :acp.actions/new-session acp/new-session)

--- a/src/gremllm/renderer/actions/acp.cljs
+++ b/src/gremllm/renderer/actions/acp.cljs
@@ -106,6 +106,6 @@
                                  acp-session-id
                                  (clj->js message))
          :on-success [[:loading.actions/set-loading? topic-id false]
-                      [:staging.actions/clear-staged topic-id]]
+                      [:excerpt.actions/clear topic-id]]
          :on-error   [[:loading.actions/set-loading? topic-id false]]}]]
       (js/console.error "[ACP] No session for prompt"))))

--- a/src/gremllm/renderer/actions/document.cljs
+++ b/src/gremllm/renderer/actions/document.cljs
@@ -14,8 +14,8 @@
   [[:ui.effects/console-error "Failed to create document:" error]])
 
 ;; TODO(design): Revisit whether document content updates should also own
-;; cross-topic staged-selection invalidation; the boundary is still unclear.
+;; cross-topic excerpt invalidation; the boundary is still unclear.
 (defn set-content [_state content]
   [[:effects/save document-state/content-path content]
-   [:staging.actions/clear-staged-across-topics]
+   [:excerpt.actions/clear-across-topics]
    [:excerpt.actions/dismiss-popover]])

--- a/src/gremllm/renderer/actions/excerpt.cljs
+++ b/src/gremllm/renderer/actions/excerpt.cljs
@@ -1,5 +1,6 @@
 (ns gremllm.renderer.actions.excerpt
-  (:require [gremllm.renderer.state.excerpt :as excerpt-state]))
+  (:require [gremllm.renderer.state.excerpt :as excerpt-state]
+            [gremllm.renderer.state.topic :as topic-state]))
 
 (defn capture->excerpt
   "Pure transform: ephemeral capture + locator-hints -> durable DocumentExcerpt.
@@ -21,10 +22,41 @@
    [:effects/save excerpt-state/anchor-path nil]
    [:effects/save excerpt-state/locator-hints-path nil]])
 
-(defn stage [state]
+(defn add [state]
   (when-let [captured (get-in state excerpt-state/captured-path)]
-    (let [locator-hints (get-in state excerpt-state/locator-hints-path)
-          id (str "excerpt-" (random-uuid))
-          excerpt (capture->excerpt captured locator-hints id)]
-      [[:staging.actions/stage excerpt]
-       [:excerpt.actions/dismiss-popover]])))
+    (when-let [topic-id (topic-state/get-active-topic-id state)]
+      (let [locator-hints (get-in state excerpt-state/locator-hints-path)
+            path          (topic-state/excerpts-path topic-id)
+            existing      (or (get-in state path) [])
+            id            (str "excerpt-" (random-uuid))
+            excerpt       (capture->excerpt captured locator-hints id)]
+        [[:effects/save path (conj existing excerpt)]
+         [:topic.actions/mark-active-unsaved]
+         [:topic.effects/auto-save topic-id]
+         [:excerpt.actions/dismiss-popover]]))))
+
+(defn remove-excerpt [state id]
+  (when-let [topic-id (topic-state/get-active-topic-id state)]
+    (let [path     (topic-state/excerpts-path topic-id)
+          existing (or (get-in state path) [])]
+      [[:effects/save path (vec (clojure.core/remove #(= (:id %) id) existing))]
+       [:topic.actions/mark-active-unsaved]
+       [:topic.effects/auto-save topic-id]])))
+
+(defn clear-active [state]
+  (when-let [topic-id (topic-state/get-active-topic-id state)]
+    (let [path (topic-state/excerpts-path topic-id)]
+      [[:effects/save path []]
+       [:topic.actions/mark-active-unsaved]
+       [:topic.effects/auto-save topic-id]])))
+
+(defn clear [_state topic-id]
+  (let [path (topic-state/excerpts-path topic-id)]
+    [[:effects/save path []]
+     [:topic.actions/mark-unsaved topic-id]
+     [:topic.effects/auto-save topic-id]]))
+
+(defn clear-across-topics [state]
+  (mapv (fn [topic-id]
+          [:effects/save (topic-state/excerpts-path topic-id) []])
+        (keys (topic-state/get-topics-map state))))

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -47,9 +47,9 @@
   (let [topic-id (or topic-id (topic-state/get-active-topic-id state))
         messages (when topic-id
                    (topic-state/get-topic-field state topic-id :messages))
-        staged-selections (when topic-id
-                            (topic-state/get-topic-field state topic-id :staged-selections))]
-    (when (or (seq messages) (seq staged-selections))
+        excerpts (when topic-id
+                   (topic-state/get-topic-field state topic-id :excerpts))]
+    (when (or (seq messages) (seq excerpts))
       [[:topic.effects/save-topic topic-id]])))
 
 (defn append-pending-diffs [state diffs]
@@ -57,40 +57,6 @@
   (let [topic-id (topic-state/get-active-topic-id state)
         existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])]
     [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing diffs)]]))
-
-(defn stage [state excerpt]
-  (let [topic-id (topic-state/get-active-topic-id state)
-        path     (topic-state/staged-selections-path topic-id)
-        existing (or (get-in state path) [])]
-    [[:effects/save path (conj existing excerpt)]
-     [:topic.actions/mark-active-unsaved]
-     [:topic.effects/auto-save topic-id]]))
-
-(defn unstage [state id]
-  (let [topic-id (topic-state/get-active-topic-id state)
-        path     (topic-state/staged-selections-path topic-id)
-        existing (or (get-in state path) [])]
-    [[:effects/save path (vec (remove #(= (:id %) id) existing))]
-     [:topic.actions/mark-active-unsaved]
-     [:topic.effects/auto-save topic-id]]))
-
-(defn clear-active-staged [state]
-  (let [topic-id (topic-state/get-active-topic-id state)
-        path     (topic-state/staged-selections-path topic-id)]
-    [[:effects/save path []]
-     [:topic.actions/mark-active-unsaved]
-     [:topic.effects/auto-save topic-id]]))
-
-(defn clear-staged [_state topic-id]
-  (let [path (topic-state/staged-selections-path topic-id)]
-    [[:effects/save path []]
-     [:topic.actions/mark-unsaved topic-id]
-     [:topic.effects/auto-save topic-id]]))
-
-(defn clear-staged-across-topics [state]
-  (mapv (fn [topic-id]
-          [:effects/save (topic-state/staged-selections-path topic-id) []])
-        (keys (topic-state/get-topics-map state))))
 
 (defn set-active
   "Set the active topic and initialize its ACP session."

--- a/src/gremllm/renderer/actions/ui.cljs
+++ b/src/gremllm/renderer/actions/ui.cljs
@@ -23,12 +23,12 @@
 (defn submit-messages [state]
   (let [text (form-state/get-user-input state)]
     (when-not (empty? text)
-      (let [staged (or (topic-state/get-staged-selections state) [])
+      (let [excerpts (or (topic-state/get-excerpts state) [])
             base-message {:id   (schema/generate-message-id)
                           :type :user
                           :text text}
-            message (if (seq staged)
-                      (assoc base-message :context {:excerpts (vec staged)})
+            message (if (seq excerpts)
+                      (assoc base-message :context {:excerpts (vec excerpts)})
                       base-message)]
         [[:messages.actions/add-to-chat message]
          [:form.actions/clear-input]

--- a/src/gremllm/renderer/state/topic.cljs
+++ b/src/gremllm/renderer/state/topic.cljs
@@ -34,11 +34,11 @@
 (defn pending-diffs-path [topic-id]
   (-> topics-path (conj topic-id :session :pending-diffs)))
 
-(defn staged-selections-path [topic-id]
-  (conj (topic-path topic-id) :staged-selections))
+(defn excerpts-path [topic-id]
+  (conj (topic-path topic-id) :excerpts))
 
-(defn get-staged-selections [state]
-  (or (:staged-selections (get-active-topic state)) []))
+(defn get-excerpts [state]
+  (or (:excerpts (get-active-topic state)) []))
 
 (defn get-acp-session-id [state topic-id]
   (get-in (get-topic state topic-id) [:session :id]))
@@ -47,4 +47,3 @@
   ;; TODO: add reverse lookup from acp-session-id to topic-id for correct
   ;; inbound routing of session updates to the originating topic
   (-> topics-path (conj topic-id :session :id)))
-

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -61,7 +61,7 @@
                           :cursor        "pointer"}
                   :on {:mousedown [[:effects/stop-propagation]]
                        :click     [[:excerpt.actions/add]]}}
-         "Stage"])]
+         "Add excerpt"])]
 
      ;; Zone 3: Chat panel
      [e/chat-panel

--- a/src/gremllm/renderer/ui.cljs
+++ b/src/gremllm/renderer/ui.cljs
@@ -29,7 +29,7 @@
         captured              (excerpt-state/get-captured state)
         anchor                (excerpt-state/get-anchor state)
         popover-pos           (excerpt-state/popover-position captured anchor)
-        staged-selections     (topic-state/get-staged-selections state)]
+        excerpts              (topic-state/get-excerpts state)]
     [e/app-layout
      ;; Zone 1: Nav strip
      [e/nav-strip {:on {:click [[:ui.actions/toggle-nav]]}}
@@ -45,7 +45,7 @@
             :active-topic-id   active-topic-id
             :topics-map        topics-map
             :renaming-topic-id renaming-topic-id})])
-      (document-ui/render-document document-content pending-diffs staged-selections)
+      (document-ui/render-document document-content pending-diffs excerpts)
       ;; TODO: not domain obvious... perhaps rename or comment?
       (when popover-pos
         [:button {:style {:position      "absolute"
@@ -60,7 +60,7 @@
                           :border        "none"
                           :cursor        "pointer"}
                   :on {:mousedown [[:effects/stop-propagation]]
-                       :click     [[:excerpt.actions/stage]]}}
+                       :click     [[:excerpt.actions/add]]}}
          "Stage"])]
 
      ;; Zone 3: Chat panel
@@ -79,7 +79,7 @@
          :loading?             (loading-state/loading? state active-topic-id)
          :has-any-api-key?     has-any-api-key?
          :pending-attachments  (form-state/get-pending-attachments state)
-         :staged-selections    staged-selections})
+         :excerpts             excerpts})
 
       (settings-ui/render-settings-modal
        (merge (sensitive-state/settings-view-props state)
@@ -89,4 +89,3 @@
   (if (workspace-state/loaded? state)
     (render-workspace state)
     (welcome-ui/render-welcome)))
-

--- a/src/gremllm/renderer/ui/chat.cljs
+++ b/src/gremllm/renderer/ui/chat.cljs
@@ -85,10 +85,10 @@
 
 (defn- render-composer-excerpts [excerpts]
   (when (seq excerpts)
-    [:div.staged-selections
+    [:div.excerpt-list
      (for [{:keys [id text]} excerpts]
-       [:span.staged-pill {:key id}
-        "selection: " (truncate text 30)
+       [:span.excerpt-chip {:key id}
+        "excerpt: " (truncate text 30)
         [:button.dismiss
          {:type "button"
           :on {:click [[:excerpt.actions/remove id]]}}
@@ -96,7 +96,7 @@
      (when (> (count excerpts) 1)
        [:button {:type "button"
                  :on {:click [[:excerpt.actions/clear-active]]}}
-        "Clear all"])]))
+        "Clear excerpts"])]))
 
 (defn- render-attachment-indicator [pending-attachments]
   (when (seq pending-attachments)

--- a/src/gremllm/renderer/ui/chat.cljs
+++ b/src/gremllm/renderer/ui/chat.cljs
@@ -83,19 +83,19 @@
    (when awaiting-response?
      (render-loading-indicator))])
 
-(defn- render-staged-selections [staged-selections]
-  (when (seq staged-selections)
+(defn- render-composer-excerpts [excerpts]
+  (when (seq excerpts)
     [:div.staged-selections
-     (for [{:keys [id text]} staged-selections]
+     (for [{:keys [id text]} excerpts]
        [:span.staged-pill {:key id}
         "selection: " (truncate text 30)
         [:button.dismiss
          {:type "button"
-          :on {:click [[:staging.actions/unstage id]]}}
+          :on {:click [[:excerpt.actions/remove id]]}}
          "✕"]])
-     (when (> (count staged-selections) 1)
+     (when (> (count excerpts) 1)
        [:button {:type "button"
-                 :on {:click [[:staging.actions/clear-active-staged]]}}
+                 :on {:click [[:excerpt.actions/clear-active]]}}
         "Clear all"])]))
 
 (defn- render-attachment-indicator [pending-attachments]
@@ -111,11 +111,11 @@
                :on {:click [[:ui.actions/clear-pending-attachments]]}}
       "Clear"]]))
 
-(defn render-input-form [{:keys [input-value loading? has-any-api-key? pending-attachments staged-selections]}]
+(defn render-input-form [{:keys [input-value loading? has-any-api-key? pending-attachments excerpts]}]
   [:footer
    [:form {:on {:submit [[:effects/prevent-default]
                          [:form.actions/submit]]}}
-    (render-staged-selections staged-selections)
+    (render-composer-excerpts excerpts)
     (render-attachment-indicator pending-attachments)
     [:fieldset {:role "group"}
      [:textarea {:class "chat-input"

--- a/src/gremllm/renderer/ui/document.cljs
+++ b/src/gremllm/renderer/ui/document.cljs
@@ -22,15 +22,15 @@
                                  "Reject"]]]))
               segments)))
 
-(defn- on-render-sync [content staged-selections]
+(defn- on-render-sync [content excerpts]
   (fn [{:replicant/keys [node life-cycle]}]
     (if (= :replicant.life-cycle/unmount life-cycle)
       (highlights/clear!)
       (do
         (locator/sync-block-metadata! node content)
-        (highlights/sync! node staged-selections)))))
+        (highlights/sync! node excerpts)))))
 
-(defn render-document [content pending-diffs staged-selections]
+(defn render-document [content pending-diffs excerpts]
   (if content
     (if (seq pending-diffs)
       (let [segments (diffs/compose content pending-diffs)]
@@ -40,7 +40,7 @@
       [:article {:on                   {:mouseup [[:excerpt.actions/capture [:event/text-selection]]]}
                  ;; Replicant lifecycle hook: after markdown renders, sync DOM
                  ;; highlight ranges against the live article node.
-                 :replicant/on-render  (on-render-sync content staged-selections)}
+                 :replicant/on-render  (on-render-sync content excerpts)}
        (md/markdown->hiccup content)])
     [:article
      [:p {:style {:color      "var(--pico-muted-color)"

--- a/src/gremllm/renderer/ui/document/highlights.cljs
+++ b/src/gremllm/renderer/ui/document/highlights.cljs
@@ -86,17 +86,17 @@
     (.setEnd   r end-node   end-offset)
     r))
 
-(defn- selection-texts [staged-selections]
-  (keep :text staged-selections))
+(defn- excerpt-texts [excerpts]
+  (keep :text excerpts))
 
 ;; TODO: is there a simpler way to do this?
 (defn sync!
-  "Rebuilds the 'staged-excerpt' highlight registry entry from the given
-   staged-selections against article's current text content. Safe to call
+  "Rebuilds the staged excerpt highlight registry entry from the given excerpts
+   against article's current text content. Safe to call
    on every render; missing matches are silently dropped."
-  [article staged-selections]
+  [article excerpts]
   (let [index  (flatten-article article)
-        ranges (->> (selection-texts staged-selections)
+        ranges (->> (excerpt-texts excerpts)
                     (keep #(locate-range-in-flat-text index %))
                     (mapv make-range))
         hl     (js/Highlight.)]
@@ -104,7 +104,7 @@
     (.set js/CSS.highlights highlight-name hl)))
 
 (defn clear!
-  "Removes the 'staged-excerpt' highlight registry entry. Call on article
+  "Removes the staged excerpt highlight registry entry. Call on article
    unmount to avoid leaving ranges that point to detached nodes."
   []
   (.delete js/CSS.highlights highlight-name))

--- a/src/gremllm/renderer/ui/document/highlights.cljs
+++ b/src/gremllm/renderer/ui/document/highlights.cljs
@@ -76,7 +76,7 @@
                  (conj parts text)
                  (conj spans [node pos (+ pos len)])))))))
 
-(def ^:private highlight-name "staged-excerpt")
+(def ^:private highlight-name "excerpt")
 
 (defn- make-range
   "Builds a DOM Range from a locate-range result and the containing document."
@@ -91,7 +91,7 @@
 
 ;; TODO: is there a simpler way to do this?
 (defn sync!
-  "Rebuilds the staged excerpt highlight registry entry from the given excerpts
+  "Rebuilds the excerpt highlight registry entry from the given excerpts
    against article's current text content. Safe to call
    on every render; missing matches are silently dropped."
   [article excerpts]
@@ -104,7 +104,7 @@
     (.set js/CSS.highlights highlight-name hl)))
 
 (defn clear!
-  "Removes the staged excerpt highlight registry entry. Call on article
+  "Removes the excerpt highlight registry entry. Call on article
    unmount to avoid leaving ranges that point to detached nodes."
   []
   (.delete js/CSS.highlights highlight-name))

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -213,7 +213,7 @@
    [:name {:default "New Topic"}        :string]
    [:session {:default {}}              AcpSession]
    [:messages {:default []}             [:vector Message]]
-   [:staged-selections {:default []}    [:vector DocumentExcerpt]]])
+   [:excerpts {:default []}             [:vector DocumentExcerpt]]])
 
 ;; TODO: Pivot domain model -- Topic should be Session.
 (def Topic

--- a/test/gremllm/main/actions/topic_test.cljs
+++ b/test/gremllm/main/actions/topic_test.cljs
@@ -13,7 +13,7 @@
           plan (topic/topic->save-plan topic topics-dir)]
       (is (= topics-dir (:dir plan)))
       (is (= "/test/dir/topic-123.edn" (:filepath plan)))
-      (is (= {:id "topic-123" :name "Test Topic" :messages [] :session {:pending-diffs []} :staged-selections []}
+      (is (= {:id "topic-123" :name "Test Topic" :messages [] :session {:pending-diffs []} :excerpts []}
              (edn/read-string (:content plan))))))
 
   (testing "strips transient fields before saving"
@@ -28,6 +28,5 @@
               :name "Test Topic"
               :messages []
               :session {:pending-diffs []}
-              :staged-selections []}
+              :excerpts []}
              (edn/read-string (:content plan)))))))
-

--- a/test/gremllm/main/effects/workspace_test.cljs
+++ b/test/gremllm/main/effects/workspace_test.cljs
@@ -14,7 +14,7 @@
 
 ;; TODO: DRY: use schema/PersistedTopic default instead of hardcoding instances
 
-(def ^:private staged-selection-fixture
+(def ^:private excerpt-fixture
   {:id "staged-1"
    :text "Our Gremllm crew"
    :locator {:document-relative-path "document.md"
@@ -33,7 +33,7 @@
 
 (deftest test-parse-topic-content
   (testing "parses valid topic content"
-    (let [topic {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []} :staged-selections []}
+    (let [topic {:id "topic-123" :name "Test" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []} :excerpts []}
           content (pr-str topic)
           result (#'workspace/parse-topic-content content "test.edn")]
       (is (= topic result))))
@@ -60,7 +60,7 @@
                         :reasoning? true
                         :messages [{:id 1754952440824 :type :user :text "Hello"}]
                         :session {:pending-diffs []}
-                        :staged-selections []}
+                        :excerpts []}
               filename (str (:id topic) ".edn")
               filepath (io/path-join temp-dir filename)
               _saved-path (workspace/save-topic {:dir temp-dir
@@ -70,8 +70,8 @@
               loaded (get all-topics (:id topic))]
           (is (= topic loaded)))))))
 
-(deftest test-save-load-round-trip-with-staged-selection
-  (testing "save and load preserves a non-empty staged selection"
+(deftest test-save-load-round-trip-with-excerpt
+  (testing "save and load preserves a non-empty excerpt"
     (with-temp-dir "topic-save-load-staged"
       (fn [temp-dir]
         (let [topic    {:id "topic-1754952422977-ixubncif66"
@@ -80,7 +80,7 @@
                         :reasoning? true
                         :messages [{:id 1754952440824 :type :user :text "Hello"}]
                         :session {:pending-diffs []}
-                        :staged-selections [staged-selection-fixture]}
+                        :excerpts [excerpt-fixture]}
               filename (str (:id topic) ".edn")
               filepath (io/path-join temp-dir filename)
               _saved-path (workspace/save-topic {:dir temp-dir
@@ -89,7 +89,7 @@
               all-topics (workspace/load-topics temp-dir)
               loaded (get all-topics (:id topic))]
           (is (= topic loaded))
-          (is (= [staged-selection-fixture] (:staged-selections loaded))))))))
+          (is (= [excerpt-fixture] (:excerpts loaded))))))))
 
 (deftest test-create-document
   (testing "creates document file and returns content"
@@ -125,8 +125,8 @@
     (with-temp-dir "load-topics"
       (fn [dir]
         ;; Simple test topics with just the essentials
-        (let [topic-1 {:id "topic-1-a" :name "First" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []} :staged-selections []}
-              topic-2 {:id "topic-2-b" :name "Second" :model "claude-sonnet-4-5-20250929" :reasoning? false :messages [] :session {:pending-diffs []} :staged-selections []}]
+        (let [topic-1 {:id "topic-1-a" :name "First" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []} :excerpts []}
+              topic-2 {:id "topic-2-b" :name "Second" :model "claude-sonnet-4-5-20250929" :reasoning? false :messages [] :session {:pending-diffs []} :excerpts []}]
 
           ;; Write valid topic files
           (write-topic-file dir topic-1)
@@ -143,7 +143,7 @@
   (testing "skips corrupt files and loads valid ones"
     (with-temp-dir "load-with-corrupt"
       (fn [dir]
-        (let [good-topic {:id "topic-111-good" :name "Valid" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []} :staged-selections []}]
+        (let [good-topic {:id "topic-111-good" :name "Valid" :model "claude-sonnet-4-5-20250929" :reasoning? true :messages [] :session {:pending-diffs []} :excerpts []}]
           ;; Write one valid and one corrupt file
           (write-topic-file dir good-topic)
           (write-file dir "topic-999-bad.edn" "{:broken")

--- a/test/gremllm/renderer/actions/acp_test.cljs
+++ b/test/gremllm/renderer/actions/acp_test.cljs
@@ -101,7 +101,7 @@
       (testing "ignores unsupported update types"
         (is (nil? (acp/session-update state {:update {:session-update :available-commands-update}})))))))
 
-(deftest send-prompt-with-message-and-staged-clears-on-success-test
+(deftest send-prompt-with-message-and-excerpts-clears-on-success-test
   (let [old-window (.-window js/globalThis)]
     (aset js/globalThis
           "window"
@@ -129,10 +129,10 @@
             [[_ _ _] promise-effect] (acp/send-prompt state message)
             on-success (get-in promise-effect [1 :on-success])
             on-error (get-in promise-effect [1 :on-error])]
-        (is (some #{[:staging.actions/clear-staged "t1"]} on-success)
-            "success clears staged selections for the originating topic")
-        (is (not (some #{[:staging.actions/clear-staged "t1"]} on-error))
-            "error preserves staged selections"))
+        (is (some #{[:excerpt.actions/clear "t1"]} on-success)
+            "success clears excerpts for the originating topic")
+        (is (not (some #{[:excerpt.actions/clear "t1"]} on-error))
+            "error preserves excerpts"))
       (finally
         (if (nil? old-window)
           (js-delete js/globalThis "window")

--- a/test/gremllm/renderer/actions/document_test.cljs
+++ b/test/gremllm/renderer/actions/document_test.cljs
@@ -9,8 +9,8 @@
       (is (= [:effects/save document-state/content-path "# Replaced"]
              (first effects))))
 
-    (testing "dispatches cross-topic staged-selection invalidation"
-      (is (some #{[:staging.actions/clear-staged-across-topics]} effects)))
+    (testing "dispatches cross-topic excerpt invalidation"
+      (is (some #{[:excerpt.actions/clear-across-topics]} effects)))
 
     (testing "dismisses live capture state"
       (is (some #{[:excerpt.actions/dismiss-popover]} effects)))))

--- a/test/gremllm/renderer/actions/excerpt_test.cljs
+++ b/test/gremllm/renderer/actions/excerpt_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer [deftest is testing]]
             [gremllm.renderer.actions.excerpt :as excerpt]
             [gremllm.renderer.state.excerpt :as excerpt-state]
+            [gremllm.renderer.state.topic :as topic-state]
             [gremllm.schema-test :as schema-test]))
 
 ;; Anchor context fixture matching AnchorContext schema
@@ -92,9 +93,12 @@
           result (excerpt/capture->excerpt captured hints "xyz")]
       (is (not (contains? (:locator result) :start-offset))))))
 
-(deftest stage-builds-document-excerpt-test
-  (testing "stage reads captured + locator-hints, dispatches staging.actions/stage with a DocumentExcerpt"
-    (let [state {:excerpt {:captured {:text "hello"}
+(deftest add-builds-and-persists-document-excerpt-test
+  (testing "add reads captured excerpt data, appends it to topic excerpts, and dismisses the popover"
+    (let [topic-id "t1"
+          state {:active-topic-id topic-id
+                 :topics {topic-id {:id topic-id :messages [] :excerpts []}}
+                 :excerpt {:captured {:text "hello"}
                            :locator-hints {:document-relative-path "document.md"
                                            :start-block {:kind :paragraph
                                                          :index 2
@@ -108,11 +112,14 @@
                                                        :block-text-snippet "hello world"}
                                            :start-offset 0
                                            :end-offset 5}}}
-          result (excerpt/stage state)
-          [[stage-action excerpt] [dismiss-action]] result]
-      (is (= :staging.actions/stage stage-action))
-      (is (= "hello" (:text excerpt)))
-      (is (string? (:id excerpt)))
+          result (excerpt/add state)
+          [save-action mark-unsaved-action auto-save-action dismiss-action] result
+          [_ save-path excerpts] save-action
+          [saved-excerpt] excerpts]
+      (is (= :effects/save (first save-action)))
+      (is (= (topic-state/excerpts-path topic-id) save-path))
+      (is (= "hello" (:text saved-excerpt)))
+      (is (string? (:id saved-excerpt)))
       (is (= {:document-relative-path "document.md"
               :start-block {:kind :paragraph
                             :index 2
@@ -126,8 +133,10 @@
                           :block-text-snippet "hello world"}
               :start-offset 0
               :end-offset 5}
-             (:locator excerpt)))
-      (is (= :excerpt.actions/dismiss-popover dismiss-action)))))
+             (:locator saved-excerpt)))
+      (is (= [:topic.actions/mark-active-unsaved] mark-unsaved-action))
+      (is (= [:topic.effects/auto-save topic-id] auto-save-action))
+      (is (= [:excerpt.actions/dismiss-popover] dismiss-action)))))
 
-(deftest stage-without-capture-is-noop-test
-  (is (nil? (excerpt/stage {}))))
+(deftest add-without-capture-is-noop-test
+  (is (nil? (excerpt/add {}))))

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -2,10 +2,8 @@
   (:require [cljs.test :refer [deftest is testing]]
             [gremllm.renderer.actions.topic :as topic]
             [gremllm.renderer.state.topic :as topic-state]
-            [gremllm.renderer.state.ui :as ui-state]
             [gremllm.schema :as schema]
             [gremllm.schema.codec :as codec]
-            [gremllm.schema-test :as schema-fixtures]
             [malli.core :as m])
   (:require-macros [gremllm.test-utils :refer [with-console-error-silenced]]))
 
@@ -104,79 +102,10 @@
         (is (= [] actions)
             "should return empty actions vector")))))
 
-(def ^:private topic-id "topic-123")
-(def ^:private base-state {:active-topic-id topic-id
-                           :topics {topic-id {:id topic-id :staged-selections []}}})
-
-(deftest stage-test
-  (let [actions (topic/stage base-state sample-excerpt)]
-    (is (= [:effects/save
-            (topic-state/staged-selections-path topic-id)
-            [sample-excerpt]]
-           (first actions)))
-    (is (= [:topic.actions/mark-active-unsaved] (nth actions 1)))
-    (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))
-
-(deftest unstage-test
-  (let [item-a sample-excerpt
-        item-b (assoc sample-excerpt :id "e2" :text "world")
-        state  (assoc-in base-state [:topics topic-id :staged-selections] [item-a item-b])]
-
-    (testing "removes item by id"
-      (let [actions (topic/unstage state "e1")]
-        (is (= [:effects/save
-                (topic-state/staged-selections-path topic-id)
-                [item-b]]
-               (first actions)))
-        (is (= [:topic.actions/mark-active-unsaved] (nth actions 1)))
-        (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))
-
-    (testing "no-op when id not found"
-      (let [actions (topic/unstage state "staged-unknown")]
-        (is (= [:effects/save
-                (topic-state/staged-selections-path topic-id)
-                [item-a item-b]]
-               (first actions)))
-        (is (= [:topic.actions/mark-active-unsaved] (nth actions 1)))
-        (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))))
-
-(deftest clear-active-staged-test
-  (let [item sample-excerpt
-        state (assoc-in base-state [:topics topic-id :staged-selections] [item])
-        actions (topic/clear-active-staged state)]
-    (is (= [:effects/save
-            (topic-state/staged-selections-path topic-id)
-            []]
-           (first actions)))
-    (is (= [:topic.actions/mark-active-unsaved] (nth actions 1)))
-    (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))
-
-(deftest clear-staged-targets-explicit-topic-test
-  (let [state {:active-topic-id "topic-999"
-               :topics {topic-id {:id topic-id
-                                  :staged-selections [sample-excerpt]}
-                        "topic-999" {:id "topic-999"
-                                     :staged-selections [(assoc sample-excerpt :id "e2")]}}}
-        actions (topic/clear-staged state topic-id)]
-    (is (= [:effects/save
-            (topic-state/staged-selections-path topic-id)
-            []]
-           (first actions)))
-    (is (= [:topic.actions/mark-unsaved topic-id] (nth actions 1)))
-    (is (= [:topic.effects/auto-save topic-id] (nth actions 2)))))
-
-(deftest auto-save-fires-when-staged-selections-present-with-no-messages-test
+(deftest auto-save-fires-when-excerpts-present-with-no-messages-test
   (let [state {:active-topic-id "t1"
                :topics {"t1" {:id "t1"
                               :messages []
-                              :staged-selections [sample-excerpt]}}}]
+                              :excerpts [sample-excerpt]}}}]
     (is (= [[:topic.effects/save-topic "t1"]]
            (topic/auto-save state "t1")))))
-
-(deftest clear-staged-across-topics-test
-  (let [state {:topics {"t1" {:id "t1" :staged-selections [{:id "a"}]}
-                        "t2" {:id "t2" :staged-selections [{:id "b"}]}}}
-        effects (topic/clear-staged-across-topics state)]
-    (is (= 2 (count effects)))
-    (is (some #{[:effects/save (topic-state/staged-selections-path "t1") []]} effects))
-    (is (some #{[:effects/save (topic-state/staged-selections-path "t2") []]} effects))))

--- a/test/gremllm/renderer/actions/ui_test.cljs
+++ b/test/gremllm/renderer/actions/ui_test.cljs
@@ -22,13 +22,13 @@
 (deftest submit-without-text-is-noop-test
   (let [state {:form {:user-input ""}
                :active-topic-id "t1"
-               :topics {"t1" {:staged-selections []}}}]
+               :topics {"t1" {:excerpts []}}}]
     (is (nil? (ui/submit-messages state)))))
 
-(deftest submit-without-staged-selections-sends-plain-message-test
+(deftest submit-without-excerpts-sends-plain-message-test
   (let [state {:form {:user-input "hello"}
                :active-topic-id "t1"
-               :topics {"t1" {:staged-selections []}}}
+               :topics {"t1" {:excerpts []}}}
         [add-msg _ _ _ send] (ui/submit-messages state)
         [_ message] add-msg
         [_ sent-message] send]
@@ -39,10 +39,10 @@
     (is (= :acp.actions/send-prompt (first send)))
     (is (= message sent-message))))
 
-(deftest submit-with-staged-selections-attaches-context-test
+(deftest submit-with-excerpts-attaches-context-test
   (let [state {:form {:user-input "reword these"}
                :active-topic-id "t1"
-               :topics {"t1" {:staged-selections [sample-excerpt]}}}
+               :topics {"t1" {:excerpts [sample-excerpt]}}}
         [add-msg _ _ _ send] (ui/submit-messages state)
         [_ message] add-msg
         [_ sent-message] send]

--- a/test/gremllm/schema_test.cljs
+++ b/test/gremllm/schema_test.cljs
@@ -213,7 +213,7 @@
       (is (m/validate schema/Message
                       (create-message {:id 1 :type :user :text "hello"}))))))
 
-(deftest persisted-topic-staged-selections-are-document-excerpts-test
+(deftest persisted-topic-excerpts-are-document-excerpts-test
   (let [excerpt {:id "e1"
                  :text "snippet"
                  :locator {:document-relative-path "document.md"
@@ -232,4 +232,4 @@
                      :name "T"
                      :session {:pending-diffs []}
                      :messages []
-                     :staged-selections [excerpt]}))))
+                     :excerpts [excerpt]}))))


### PR DESCRIPTION
This renames the persisted topic field, renderer state paths, action names, and UI labels from staged selections to excerpts so the terminology matches the document excerpt domain. It also moves add/remove/clear behavior under `excerpt.actions/*`, which removes staging-specific topic action plumbing while preserving autosave behavior. The tradeoff is a broad rename touching schema, UI, and tests in one branch.