### PR TITLE
test(excerpt): focus staged selection context coverage

### DIFF
--- a/test/gremllm/main/actions/acp_test.cljs
+++ b/test/gremllm/main/actions/acp_test.cljs
@@ -2,103 +2,58 @@
   (:require [cljs.test :refer [deftest is testing]]
             [gremllm.main.actions.acp :as acp]))
 
+(def ^:private excerpt
+  {:id "e1"
+   :text "launched on a Tuesday"
+   :locator {:document-relative-path "document.md"
+             :start-block {:kind :paragraph
+                           :index 2
+                           :start-line 3
+                           :end-line 3
+                           :block-text-snippet "Our Gremllm launched on a Tuesday."}
+             :end-block {:kind :paragraph
+                         :index 2
+                         :start-line 3
+                         :end-line 3
+                         :block-text-snippet "Our Gremllm launched on a Tuesday."}}})
+
 (deftest text-only-message-test
-  (testing "message with no :context produces single text block"
+  (testing "message with no :context produces a single text block"
     (is (= [{:type "text" :text "hello"}]
            (acp/prompt-content-blocks {:text "hello"} nil)))))
 
-(deftest text-only-with-document-path-test
-  (is (= [{:type "text" :text "hello"}
-          {:type "resource_link"
-           :uri "file:///workspace/document.md"
-           :name "document.md"}]
-         (acp/prompt-content-blocks {:text "hello"} "/workspace/document.md"))))
+(deftest excerpt-bearing-message-test
+  (let [message {:text "reword these"
+                 :context {:excerpts [excerpt]}}
+        blocks-without-document (acp/prompt-content-blocks message nil)
+        blocks-with-document (acp/prompt-content-blocks message "/workspace/document.md")
+        text-block (first blocks-without-document)
+        body (:text text-block)]
+    (testing "without a document path only the text block is returned"
+      (is (= 1 (count blocks-without-document)))
+      (is (= "text" (:type text-block)))
+      (is (re-find #"reword these" body))
+      (is (re-find #"References:" body))
+      (is (re-find #"launched on a Tuesday" body))
+      (is (re-find #"p2" body)))
 
-(deftest same-block-excerpt-includes-text-and-label-test
-  (let [excerpt {:id "e1"
-                 :text "launched on a Tuesday"
-                 :locator {:document-relative-path "document.md"
-                           :start-block {:kind :paragraph
-                                         :index 2
-                                         :start-line 3
-                                         :end-line 3
-                                         :block-text-snippet "Our Gremllm launched on a Tuesday."}
-                           :end-block {:kind :paragraph
-                                       :index 2
-                                       :start-line 3
-                                       :end-line 3
-                                       :block-text-snippet "Our Gremllm launched on a Tuesday."}}}
-        message {:text "reword these"
+    (testing "with a document path a resource_link block is appended"
+      (is (= 2 (count blocks-with-document)))
+      (is (= "text" (:type (first blocks-with-document))))
+      (is (= {:type "resource_link"
+              :uri "file:///workspace/document.md"
+              :name "document.md"}
+             (second blocks-with-document))))))
+
+(deftest excerpt-rendering-format-test
+  (let [message {:text "reword"
                  :context {:excerpts [excerpt]}}
         [text-block] (acp/prompt-content-blocks message nil)
         body (:text text-block)]
-    (is (= "text" (:type text-block)))
-    (is (re-find #"reword these" body))
-    (is (re-find #"References:" body))
-    (is (re-find #"launched on a Tuesday" body))
-    (is (re-find #"p2" body))
-    (is (not (re-find #"offset" body)))
-    (is (re-find #"Our Gremllm launched on a Tuesday\." body))))
-
-(deftest cross-block-excerpt-no-offsets-test
-  (let [excerpt {:id "e2"
-                 :text "Gremllm Launch Log\nOur Gremllm"
-                 :locator {:document-relative-path "document.md"
-                           :start-block {:kind :heading
-                                         :index 1
-                                         :start-line 1
-                                         :end-line 1
-                                         :block-text-snippet "Gremllm Launch Log"}
-                           :end-block {:kind :paragraph
-                                       :index 2
-                                       :start-line 3
-                                       :end-line 3
-                                       :block-text-snippet "Our Gremllm launched on a Tuesday."}}}
-        message {:text "compare these"
-                 :context {:excerpts [excerpt]}}
-        [text-block] (acp/prompt-content-blocks message nil)
-        body (:text text-block)]
-    (is (re-find #"h1 -> p2" body))
-    (is (not (re-find #"offset" body)))))
-
-(deftest excerpt-text-renders-as-blockquote-test
-  (testing "excerpt text is rendered as markdown blockquote, not pr-str quoted"
-    (let [excerpt {:id "e1"
-                   :text "launched on a Tuesday"
-                   :locator {:document-relative-path "document.md"
-                             :start-block {:kind :paragraph
-                                           :index 2
-                                           :start-line 3
-                                           :end-line 3
-                                           :block-text-snippet "Our Gremllm launched on a Tuesday."}
-                             :end-block {:kind :paragraph
-                                         :index 2
-                                         :start-line 3
-                                         :end-line 3
-                                         :block-text-snippet "Our Gremllm launched on a Tuesday."}}}
-          message {:text "reword" :context {:excerpts [excerpt]}}
-          [text-block] (acp/prompt-content-blocks message nil)
-          body (:text text-block)]
+    (testing "excerpt text is rendered as markdown blockquote content"
       (is (re-find #"      > launched on a Tuesday" body))
-      (is (not (re-find #"\"launched" body))))))
+      (is (not (re-find #"\"launched on a Tuesday\"" body))))
 
-(deftest excerpt-with-document-path-appends-resource-link-test
-  (let [excerpt {:id "e1"
-                 :text "x"
-                 :locator {:document-relative-path "document.md"
-                           :start-block {:kind :paragraph
-                                         :index 2
-                                         :start-line 3
-                                         :end-line 3
-                                         :block-text-snippet "x"}
-                           :end-block {:kind :paragraph
-                                       :index 2
-                                       :start-line 3
-                                       :end-line 3
-                                       :block-text-snippet "x"}}}
-        blocks (acp/prompt-content-blocks
-                {:text "t" :context {:excerpts [excerpt]}}
-                "/workspace/document.md")]
-    (is (= 2 (count blocks)))
-    (is (= "text" (:type (first blocks))))
-    (is (= "resource_link" (:type (second blocks))))))
+    (testing "block context is rendered in its own labeled section"
+      (is (re-find #"block context:" body))
+      (is (re-find #"      > Our Gremllm launched on a Tuesday\." body)))))

--- a/test/gremllm/renderer/actions/excerpt_test.cljs
+++ b/test/gremllm/renderer/actions/excerpt_test.cljs
@@ -65,20 +65,30 @@
             [:effects/save excerpt-state/locator-hints-path nil]]
            (excerpt/dismiss-popover {})))))
 
-(deftest capture->excerpt-same-block-test
-  (testing "builds DocumentExcerpt from captured text and same-block locator-hints"
-    (let [captured {:text "launched on a Tuesday"
-                    :range-count 1
-                    :anchor-node "#text"
-                    :anchor-offset 4
-                    :focus-node "#text"
-                    :focus-offset 25
-                    :range {}}
-          hints locator-hints
-          result (excerpt/capture->excerpt captured hints "abc-123")]
-      (is (= "abc-123" (:id result)))
-      (is (= "launched on a Tuesday" (:text result)))
-      (is (= hints (:locator result))))))
+(deftest remove-excerpt-filters-active-topic-excerpts-and-autosaves-test
+  (testing "remove-excerpt removes only the matching id, preserves order, and emits persistence side effects"
+    (let [topic-id "t1"
+          first-excerpt {:id "e-1"
+                         :text "keep first"
+                         :locator locator-hints}
+          removed-excerpt {:id "e-2"
+                           :text "remove me"
+                           :locator locator-hints}
+          last-excerpt {:id "e-3"
+                        :text "keep last"
+                        :locator locator-hints}
+          state {:active-topic-id topic-id
+                 :topics {topic-id {:id topic-id
+                                    :messages []
+                                    :excerpts [first-excerpt removed-excerpt last-excerpt]}}}
+          result (excerpt/remove-excerpt state "e-2")
+          [save-action mark-unsaved-action auto-save-action] result]
+      (is (= [:effects/save
+              (topic-state/excerpts-path topic-id)
+              [first-excerpt last-excerpt]]
+             save-action))
+      (is (= [:topic.actions/mark-active-unsaved] mark-unsaved-action))
+      (is (= [:topic.effects/auto-save topic-id] auto-save-action)))))
 
 
 (deftest add-builds-and-persists-document-excerpt-test

--- a/test/gremllm/renderer/ui/chat_test.cljs
+++ b/test/gremllm/renderer/ui/chat_test.cljs
@@ -62,29 +62,20 @@
                          :block-text-snippet "Body"}}})
 
 (deftest plain-user-message-has-no-references-test
-  (let [hiccup (#'chat-ui/render-message
-                (schema-test/create-message {:id 1 :type :user :text "hello"}))]
-    (is (not (contains-text? hiccup "References")))
+  (let [hiccup (chat-ui/render-chat-area
+                [(schema-test/create-message {:id 1 :type :user :text "hello"})]
+                false)]
+    (is (nil? (lookup/select-one '.message-references hiccup)))
     (is (contains-text? hiccup "hello"))))
 
-(deftest user-message-with-same-block-excerpt-renders-compact-pill-test
-  (let [hiccup (#'chat-ui/render-message
-                (schema-test/create-message
+(deftest user-message-with-excerpts-renders-reference-affordances-test
+  (let [hiccup (chat-ui/render-chat-area
+                [(schema-test/create-message
                   {:id 1
                    :type :user
                    :text "reword these"
-                   :context {:excerpts [same-block-excerpt]}}))]
+                   :context {:excerpts [same-block-excerpt cross-block-excerpt]}})]
+                false)]
     (is (contains-text? hiccup "reword these"))
-    (is (contains-text? hiccup "p3"))
-    (is (contains-text? hiccup "this is a selection longer than forty c"))
-    (is (not (contains-text? hiccup "full block text")))
-    (is (not (contains-text? hiccup "this is a selection longer than forty characters abc")))))
-
-(deftest user-message-with-cross-block-excerpt-renders-arrow-label-test
-  (let [hiccup (#'chat-ui/render-message
-                (schema-test/create-message
-                  {:id 1
-                   :type :user
-                   :text "compare"
-                   :context {:excerpts [cross-block-excerpt]}}))]
-    (is (contains-text? hiccup "h1 -> p2"))))
+    (is (some? (lookup/select-one '.message-references hiccup)))
+    (is (= 2 (count (lookup/select '.excerpt-pill hiccup))))))

--- a/test/gremllm/schema_test.cljs
+++ b/test/gremllm/schema_test.cljs
@@ -162,24 +162,12 @@
                :start-line 3
                :end-line 3
                :block-text-snippet "Our Gremllm launched on a Tuesday."}]
-    (testing "same-block excerpt"
+    (testing "valid DocumentExcerpt validates"
       (is (m/validate schema/DocumentExcerpt
                       {:id "excerpt-abc"
                        :text "launched on a Tuesday"
                        :locator {:document-relative-path "document.md"
                                  :start-block block
-                                 :end-block block}})))
-    (testing "cross-block excerpt without offsets"
-      (is (m/validate schema/DocumentExcerpt
-                      {:id "excerpt-xyz"
-                       :text "Gremllm Launch Log\nOur Gremllm"
-                       :locator {:document-relative-path "document.md"
-                                 :start-block (assoc block
-                                                     :kind :heading
-                                                     :index 1
-                                                     :start-line 1
-                                                     :end-line 1
-                                                     :block-text-snippet "Gremllm Launch Log")
                                  :end-block block}})))
     (testing "missing :locator fails"
       (is (not (m/validate schema/DocumentExcerpt


### PR DESCRIPTION
This tightens regression coverage for staged selection context without changing runtime behavior. The updates focus ACP prompt content formatting, excerpt removal side effects, chat reference affordances, and DocumentExcerpt schema validation against the current excerpt model. The tradeoff is narrower, more intentional assertions in place of broader duplicate test cases.