### PR TITLE
docs: capture ACP launch research and reframe the packaged-app spike plan

### DIFF
--- a/docs/2026-04-20-acp-packaged-app-launch-r1-r4-research-memo.md
+++ b/docs/2026-04-20-acp-packaged-app-launch-r1-r4-research-memo.md
@@ -1,0 +1,153 @@
+# Research Memo: ACP Packaged-App Launch (R1-R4)
+
+**Date:** 2026-04-20
+**Status:** Research findings only
+**Related:** [Investigation spec](/Users/paul/Projects/gremllm/.worktrees/packaged-agent-launch/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md), [Research and spikes plan](/Users/paul/Projects/gremllm/.worktrees/packaged-agent-launch/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md)
+
+This memo records the findings from research items `R1` to `R4` in the packaged-app agent launch plan. It intentionally does **not** choose an option or synthesize a recommendation. Where a point is not directly stated by a source, it is labeled as an inference.
+
+## R1. Zed's Packaging of ACP Agents
+
+### Findings
+
+- Zed documents external agents as processes it runs in the background and talks to over ACP, not as libraries embedded into the editor process.
+- For Claude Agent, Zed documents a managed first-use install of `@zed-industries/claude-agent-acp`, and states that this managed adapter includes a vendored Claude Code CLI even if Claude Code is also installed globally.
+- Zed supports overriding the Claude executable via `CLAUDE_CODE_EXECUTABLE`, which indicates the adapter ultimately launches an executable rather than exposing only an in-process library surface.
+- For Codex, Zed likewise documents a managed first-use install of `codex-acp`.
+- The ACP registry entry current on **April 20, 2026** lists `claude-acp` as an `npx` distribution and `codex-acp` as a binary distribution with an `npx` fallback.
+- Zed's runtime code supports both registry binary agents and registry `npx` agents.
+- Zed's node runtime code prefers a working system Node/npm, but also supports downloading and using a Zed-managed Node runtime when allowed.
+
+### Evidence
+
+- Zed docs say Gemini CLI is run in the background and spoken to over ACP, and say for Claude Agent: "Under the hood, Zed runs the Claude Agent SDK, which runs Claude Code under the hood, and communicates to it over ACP, through a dedicated adapter."
+  Source: [Zed external agents docs](https://zed.dev/docs/ai/external-agents)
+- The same docs say: "The first time you create a Claude Agent thread, Zed will install `@zed-industries/claude-agent-acp`" and that Zed will use this managed version, which includes a vendored Claude Code CLI.
+  Source: [Zed external agents docs](https://zed.dev/docs/ai/external-agents)
+- The same docs document `CLAUDE_CODE_EXECUTABLE` as an override.
+  Source: [Zed external agents docs](https://zed.dev/docs/ai/external-agents)
+- The current ACP registry lists `claude-acp` with `distribution.npx` and `codex-acp` with `distribution.binary` plus `distribution.npx`.
+  Source: [ACP registry](https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json)
+- Zed's agent server store handles both `RegistryAgent::Binary` and `RegistryAgent::Npx`, constructing `LocalRegistryArchiveAgent` or `LocalRegistryNpxAgent` accordingly.
+  Source: [agent_server_store.rs](https://raw.githubusercontent.com/zed-industries/zed/main/crates/project/src/agent_server_store.rs)
+- Zed's node runtime code includes `allow_binary_download`, `run_npm_subcommand`, and managed Node download paths from `nodejs.org`.
+  Source: [node_runtime.rs](https://raw.githubusercontent.com/zed-industries/zed/main/crates/node_runtime/src/node_runtime.rs)
+
+### Unresolved Gaps
+
+- The research did not inspect a packaged Zed app artifact directly.
+- This research did not establish whether Zed ever embeds an ACP agent library in-process for any agent. The documented path is process-based.
+
+## R2. Other Electron-Based Agent Apps
+
+### Findings
+
+- Continue and Cline publicly document subprocess-style MCP transports and also show their core agent logic running in-process in the VS Code extension host.
+- Continue's VS Code extension entrypoint is `./out/extension.js`, and its extension source constructs `InProcessMessenger` and `Core`.
+- Cline's extension entrypoint is `./dist/extension.js`, and its MCP source imports and constructs `StdioClientTransport`, `SSEClientTransport`, and `StreamableHTTPClientTransport`.
+- Cursor and Windsurf publicly document MCP transports, including `stdio`, but this research did not find direct public evidence for how their core agent runtime is packaged or isolated.
+- This research did not find evidence that any of the surveyed products ship a Bun-compiled helper for the core agent runtime.
+
+### Evidence
+
+- Continue's extension package sets `"main": "./out/extension.js"`.
+  Source: [Continue VS Code package](https://raw.githubusercontent.com/continuedev/continue/main/extensions/vscode/package.json)
+- Continue's extension source imports `InProcessMessenger` and constructs both `new InProcessMessenger(...)` and `new Core(...)`.
+  Source: [Continue VsCodeExtension.ts](https://raw.githubusercontent.com/continuedev/continue/main/extensions/vscode/src/extension/VsCodeExtension.ts)
+- Continue's MCP docs show `stdio` MCP configuration using `command` and `args`.
+  Source: [Continue MCP docs](https://docs.continue.dev/customize/deep-dives/mcp)
+- Cline's package sets `"main": "./dist/extension.js"`.
+  Source: [Cline package](https://raw.githubusercontent.com/cline/cline/main/package.json)
+- Cline's MCP source imports `StdioClientTransport`, `SSEClientTransport`, and `StreamableHTTPClientTransport`, and constructs the stdio transport with command-based configuration.
+  Source: [Cline McpHub.ts](https://raw.githubusercontent.com/cline/cline/main/src/services/mcp/McpHub.ts)
+- Cline's MCP docs describe `stdio`, `SSE`, and `streamable HTTP` transport mechanisms.
+  Source: [Cline MCP transport docs](https://docs.cline.bot/mcp/mcp-transport-mechanisms)
+- Cursor's MCP docs describe local `stdio` configuration with `command`, `args`, and `env`.
+  Source: [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol)
+- Windsurf's MCP docs describe `stdio`, `Streamable HTTP`, and `SSE` configuration with command-based examples.
+  Source: [Windsurf MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp)
+
+### Inference
+
+- Continue and Cline provide direct evidence that editor-hosted agent logic plus subprocess MCP integrations is a real pattern in adjacent tools.
+- Cursor and Windsurf provide direct evidence for subprocess MCP support, but not for their internal process model for the core agent runtime.
+
+### Unresolved Gaps
+
+- No direct public packaging evidence was found for Cursor's core agent runtime.
+- No direct public packaging evidence was found for Windsurf's core agent runtime.
+- No direct evidence was found for Bun-compiled helpers in this product set.
+
+## R3. `utilityProcess` and Bidirectional Stream Patterns
+
+### Findings
+
+- Electron's `utilityProcess` supports bidirectional message passing through `postMessage` and `process.parentPort`, but does not expose writable stdin for the child.
+- ACP explicitly allows custom transports as long as they preserve ACP's JSON-RPC lifecycle and bidirectional message exchange.
+- The ACP SDK connection types operate over a generic stream abstraction rather than requiring OS stdio specifically.
+- Electron's ASAR docs document important packaging constraints: `cwd` cannot point inside an ASAR archive, and binaries inside ASAR are a special case that generally require unpacking.
+- This research did not find an official Electron example of NDJSON-over-`MessagePort` specifically for `utilityProcess`.
+
+### Evidence
+
+- Electron documents `utilityProcess.fork()` and shows `child.postMessage(...)` with transferred `MessagePortMain` objects; it also documents that `stdin` is ignored while `stdout` and `stderr` are available.
+  Source: [Electron utilityProcess docs](https://www.electronjs.org/docs/latest/api/utility-process)
+- Electron documents MessagePort-based patterns and notes lifecycle details such as starting the port on the main side.
+  Source: [Electron MessagePorts tutorial](https://www.electronjs.org/docs/latest/tutorial/message-ports/)
+- ACP transport docs state that ACP is transport-agnostic and may be implemented over custom transports that preserve bidirectional JSON-RPC exchange.
+  Source: [ACP transport docs](https://agentclientprotocol.com/protocol/transports)
+- Electron's ASAR docs say that `cwd` cannot be set inside ASAR and that unpacking is the usual workaround for executable/native cases.
+  Source: [Electron ASAR docs](https://www.electronjs.org/docs/latest/tutorial/asar-archives)
+
+### Inference
+
+- A `MessagePort` to stream adapter appears feasible at the protocol boundary, but the adapter would be application-owned rather than a documented off-the-shelf pattern.
+- A JavaScript `utilityProcess` entrypoint inside `app.asar` may be workable, but any binary/helper path should be treated as an unpacking question rather than assumed to work unchanged.
+
+### Unresolved Gaps
+
+- No official end-to-end example was found for NDJSON or JSON-RPC over `MessagePort` in a `utilityProcess`.
+- This research did not establish a documented ACP SDK helper for `MessagePort` transport adaptation.
+- This research did not directly verify whether a packaged `utilityProcess` entrypoint should live in `app.asar` or `app.asar.unpacked`.
+
+## R4. `claude-agent-acp` EMFILE / Settings Watcher Origin
+
+### Findings
+
+- `claude-agent-acp` creates a `SettingsManager` during session creation, not at import time.
+- `SettingsManager.initialize()` sets up watchers over multiple settings file locations.
+- The settings manager code watches user, project, local, and managed settings paths.
+- `claude-agent-acp` passes `settingSources: ["user", "project", "local"]` into the Anthropic SDK path during session creation.
+- Anthropic's SDK docs document `settingSources` as the mechanism for disabling user/project/local filesystem settings, including `settingSources: []`.
+- This research did not find a documented adapter-level option or environment variable in `claude-agent-acp` to disable its own `SettingsManager` watcher behavior.
+- Upstream issue history shows watcher-related exhaustion as a real reported problem, and `claude-agent-acp` has already fixed at least one watcher-leak bug.
+
+### Evidence
+
+- In `claude-agent-acp`, `createSession(...)` constructs `new SettingsManager(params.cwd, ...)`.
+  Source: [acp-agent.ts](https://github.com/agentclientprotocol/claude-agent-acp/blob/main/src/acp-agent.ts)
+- The same file sets `settingSources: ["user", "project", "local"]`.
+  Source: [acp-agent.ts](https://github.com/agentclientprotocol/claude-agent-acp/blob/main/src/acp-agent.ts)
+- In `settings.ts`, `initialize()` calls `setupWatchers()`, and `setupWatchers()` includes user, project, local, and managed settings paths and calls `fs.watch(...)`.
+  Source: [settings.ts](https://github.com/agentclientprotocol/claude-agent-acp/blob/main/src/settings.ts)
+- Anthropic's TypeScript SDK docs describe `settingSources`, including the ability to disable user/project/local settings by supplying an empty list.
+  Source: [Anthropic Agent SDK TypeScript docs](https://code.claude.com/docs/en/agent-sdk/typescript)
+- Anthropic issue `#7624` reports startup failure from settings file watcher exhaustion and is closed as `not planned`.
+  Source: [anthropics/claude-code#7624](https://github.com/anthropics/claude-code/issues/7624)
+- `claude-agent-acp` PR `#454` fixes a session leak that left active `fs.watch()` descriptors behind.
+  Source: [claude-agent-acp PR #454](https://github.com/agentclientprotocol/claude-agent-acp/pull/454)
+
+### Inference
+
+- The local `EMFILE` warning is consistent with real watcher behavior in the adapter and not solely with a synthetic sandbox artifact.
+- Because `claude-agent-acp` runs its own settings watcher and also opts into SDK filesystem setting sources, more than one settings-related mechanism may be active during a session.
+
+### Unresolved Gaps
+
+- This research did not establish whether `settingSources: []` would remove all SDK-side watcher behavior in the relevant runtime path.
+- This research did not find a documented non-fork way to disable the adapter's own watcher behavior.
+
+## Notes on Scope
+
+- This memo records research findings only.
+- No option selection, prioritization, or spike outcome synthesis is included here.

--- a/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md
+++ b/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md
@@ -1,7 +1,7 @@
 # Plan: Research and Spikes for ACP Packaged-App Agent Launch
 
 **Date:** 2026-04-20
-**Status:** Proposed
+**Status:** Updated post R1–R4 research
 **Input spec:** [docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md](/Users/paul/Projects/gremllm/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md)
 
 ## Context
@@ -9,7 +9,7 @@
 The investigation spec enumerated six options (A–F) for fixing the packaged-app `spawn npx ENOENT` failure. We need an evidence-based decision, but only C has a local POC and only B has concrete variants documented — the rest are docs-only. This plan closes those gaps by:
 
 1. **Web research** to surface real-world precedent and de-risk unknowns before committing engineering time.
-2. **Three spikes** to validate the top candidates (C, A, D) against real packaged-app behavior, not sandbox probes.
+2. **Two spikes** to validate the top candidates (A, then C as fallback) against real packaged-app behavior, not sandbox probes.
 
 User priors (from brainstorming):
 
@@ -17,7 +17,8 @@ User priors (from brainstorming):
 - Release-toolchain additions: **open, pending research** — whether adding Bun or a bundled Node runtime is worth it depends on what other Electron agent apps actually ship.
 - Decision factors are **all of: library behavior (C), transport-rewrite cost (A), real-world precedent (research)** — multi-factor, not binary.
 
-Viable set going in: **A (utilityProcess)**, **B (packaged launcher)**, **C (in-process)**, **D (worker thread)**.
+Viable set after R1–R4: **A (utilityProcess)**, **C (in-process)**. B held in reserve.
+Dropped during research: D (workers share parent OS process — no fd isolation, only sync crash containment; not a flagged risk).
 Eliminated: E (security regression), F (not self-contained).
 
 ## Web Research Items
@@ -68,26 +69,59 @@ The local POC surfaced `EMFILE` settings-watcher warnings. Identify the source b
 
 **Tells us:** whether the warning is a sandbox artifact we can ignore, or a real integration concern that affects C's viability.
 
-### R5. Bun single-file executable: macOS signing/notarization track record
+### R5. Bundled Node runtime + JS entrypoint via `execFile` in Electron Forge
 
-Only matters if research lands us on B.
+Only if B is reopened. R1 establishes this sub-variant (Zed's managed-Node-runtime approach) as the one with real production precedent. Bun and Node SEA are no longer the priority B variants.
 
 **Questions:**
-- Do signed/notarized macOS apps successfully ship Bun-compiled helpers today?
-- Hardened runtime compatibility?
-- Artifact size implications?
+- How to package a Node runtime binary via Electron Forge for macOS (signing, notarization, `asarUnpack` placement)?
+- What does `execFile` look like targeting a bundled runtime + JS entrypoint from `process.resourcesPath`?
 
-**Tells us:** whether B's Bun variant is production-realistic or still has rough edges.
+**Tells us:** whether the bundled-Node B variant is production-realistic as a fallback if A and C both fail.
 
-### R6. Node SEA maturity for ESM packages (2026)
+**Research stop condition:** when R1–R4 converge on a direction, stop. R5 only runs if B becomes a contender.
 
-Same scope: only matters if B becomes serious and Bun is ruled out.
+## Spike 1: `utilityProcess`-Hosted ACP (Option A) *(run first)*
 
-**Tells us:** whether the SEA variant of B is worth even considering, or still blocked by the CJS-only limitation the spec noted.
+### Goal
 
-**Research stop condition:** when R1–R4 converge on a direction, stop. R5–R6 only run if B becomes a contender.
+Determine the real transport-rewrite cost of A, and whether `utilityProcess`'s stdin-ignore constraint is prohibitive in practice. R1 (Zed) establishes subprocess-with-embedded-runtime as the production precedent for ACP agent hosting; this spike validates that Electron's native subprocess primitive fits the shape.
 
-## Spike 1: Harden In-Process ACP (Option C)
+### Hypothesis being tested
+
+> A `utilityProcess` entrypoint hosting `ClaudeAcpAgent` can bridge its NDJSON streams to `MessagePort` messages with a transport adapter small enough (≤~100 lines) that A's incremental cost over C is worth paying for the OS-process isolation benefit.
+
+### Scope
+
+1. Create a packaged child entrypoint (JS) that constructs `ClaudeAcpAgent` and exposes its ACP transport as a MessagePort-backed stream pair.
+2. `utilityProcess.fork()` it from the main process; set up MessagePort.
+3. Adapt the main-process ACP client to feed `ClientSideConnection` a `ReadableStream`/`WritableStream` pair that reads/writes MessagePort messages instead of stdin/stdout bytes.
+4. Verify dev mode first: real session with document.md read, pending-diff streaming, multi-turn, resume-session.
+5. Verify packaged mode: install to `/Applications`, launch from Finder, run the same session end-to-end.
+6. Determine empirically whether the utility-process entrypoint loads from `app.asar` or needs `asarUnpack`.
+7. Expose a `CLAUDE_AGENT_ACP_EXECUTABLE`-style env override for local dev/debug (analogous to Zed's `CLAUDE_CODE_EXECUTABLE`).
+
+### Exit criteria (must all pass)
+
+- Full session works through MessagePort transport in packaged mode.
+- Transport adapter ≤~100 lines total (main side + child side). This is the **cost bound** — if it blows past, "low transport cost" is falsified and the spike tells us to prefer C.
+- Utility-process child survives parent-process signals correctly (clean shutdown, restart).
+- Asar-loading question has a definitive answer (works / needs unpack / needs bundling step).
+- No regression in pending-diff rendering (`schema.codec` normalization still produces correct shape).
+- `acp/resume-session` works across app restarts in packaged mode.
+- Adapter-internal Claude Code CLI subprocess launches correctly in packaged mode; `asarUnpack` need for the vendored CLI determined.
+
+### What we'd learn
+
+- The real answer to "is A a meaningful rewrite, or a clean refactor?"
+- Whether Electron's officially-recommended primitive fits the ACP bridge shape.
+- If A passes, we ship — no further spikes needed.
+
+### Rollback
+
+Spike runs on a branch; no production paths touched until a decision is made.
+
+## Spike 2: Harden In-Process ACP (Option C) *(fallback — run only if Spike 1 fails)*
 
 ### Goal
 
@@ -103,132 +137,56 @@ Determine whether in-process hosting is production-viable, or whether the POC's 
 2. Wire it behind a feature flag in [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) so dev mode can toggle between subprocess and in-process.
 3. Verify dev mode first: real session with document.md read, pending-diff streaming, multi-turn, resume-session.
 4. Verify packaged mode: install to `/Applications`, launch from Finder, run the same session end-to-end.
-5. Identify EMFILE origin using R4's findings.
+5. Verify `claude-agent-acp` PR #454 (watcher leak fix) is present in the bundled version; patch or upgrade if not.
+6. Confirm adapter-internal Claude Code CLI subprocess launches correctly in packaged mode (same asar concern as Spike 1).
 
 ### Exit criteria (must all pass)
 
 - Clean session ≥10 minutes of real document work; no crashes, no event-loop stalls.
-- EMFILE warning root cause identified and either eliminated or documented as benign.
+- EMFILE warning root cause identified (per R4: per-session `SettingsManager` watchers + SDK `settingSources` watchers) and either eliminated or documented as stable with a measured ceiling.
+- fd count stable across **N full sessions** (create + tear down cycle), not just N prompts within one session. Watcher lifecycle is per-session; this is the correct signal.
 - No regression in pending-diff rendering (`schema.codec` normalization still produces correct shape).
 - `acp/resume-session` works across app restarts in packaged mode.
-- fd count stable across 10+ prompts (no leak).
+- Adapter-internal Claude Code CLI subprocess launches correctly in packaged mode; `asarUnpack` need for the vendored CLI determined.
 
 ### What we'd learn
 
-- Is C the simplest viable path? (prior: yes)
-- If it fails, what's the blocker: library environment assumptions, runtime fragility, or process-model mismatch? That failure mode informs whether A or B is the fallback.
+- Is C production-viable as a fallback? If yes, and A's transport adapter exceeded its cost bound, pick C.
+- Failure mode shapes the B decision: library environment assumptions → B likely needed; runtime fragility → B still needed; watcher fd exhaustion → document ceiling and accept.
 
 ### Rollback
 
 Feature flag defaults off; subprocess path remains untouched.
 
-## Spike 2: `utilityProcess`-Hosted ACP (Option A)
-
-### Goal
-
-Determine the real transport-rewrite cost of A, and whether `utilityProcess`'s stdin-ignore constraint is prohibitive in practice.
-
-### Hypothesis being tested
-
-> A `utilityProcess` entrypoint hosting `ClaudeAcpAgent` can bridge its NDJSON streams to `MessagePort` messages with a transport adapter small enough (≤~100 lines) that A's incremental cost over C is worth paying for the process-isolation benefit.
-
-### Scope
-
-1. Create a packaged child entrypoint (JS) that constructs `ClaudeAcpAgent` and exposes its ACP transport as a MessagePort-backed stream pair.
-2. `utilityProcess.fork()` it from the main process; set up MessagePort.
-3. Adapt the main-process ACP client to feed `ClientSideConnection` a `ReadableStream`/`WritableStream` pair that reads/writes MessagePort messages instead of stdin/stdout bytes.
-4. Verify the same end-to-end behavior as Spike 1's exit criteria.
-5. Decide empirically whether the utility-process entrypoint loads from `app.asar` or needs `asarUnpack`.
-
-### Exit criteria (must all pass)
-
-- Full session works through MessagePort transport in packaged mode.
-- Transport adapter ≤ ~100 lines total (main side + child side). This is the **cost bound** — if it blows past, "low transport cost" is falsified and the spike tells us to prefer C.
-- Utility-process child survives parent-process signals correctly (clean shutdown, restart).
-- Asar-loading question has a definitive answer (works / needs unpack / needs bundling step).
-
-### What we'd learn
-
-- The real answer to "is A a meaningful rewrite, or a clean refactor?"
-- Whether Electron's officially-recommended primitive fits the ACP bridge shape.
-- Joint with Spike 1's result: the actual A-vs-C comparison, evidence-based.
-
-### Rollback
-
-Spike runs on a branch; no production paths touched until a decision is made.
-
-## Spike 3: `worker_threads`-Hosted ACP (Option D)
-
-### Goal
-
-Determine whether a worker-thread host provides meaningful isolation (crash containment for ordinary JS failures, CPU isolation) at lower transport and packaging cost than Option A, while avoiding main-process coupling that Option C accepts.
-
-### Hypothesis being tested
-
-> A `worker_threads` Worker hosting `ClaudeAcpAgent` delivers enough isolation from the Electron main process to contain ordinary library failures, and its `MessagePort` transport is cheaper to build than `utilityProcess`'s (because Worker integrates more natively with Node streams and loads JS directly without the packaged-entrypoint questions `utilityProcess` raises).
-
-### Scope
-
-1. Create a Worker entrypoint that constructs `ClaudeAcpAgent` and exposes its ACP transport over the Worker's `parentPort`.
-2. Main process spawns the Worker via `new Worker(...)` and adapts `ClientSideConnection` to read/write through `MessagePort`.
-3. Reuse as much of Spike 2's transport-adapter code as possible — the `MessagePort` ↔ `ReadableStream`/`WritableStream` bridge is the same shape.
-4. Verify the same end-to-end exit criteria as Spike 1 in packaged mode.
-5. Confirm Electron's embedded Node in the main process gives the Worker a Node environment sufficient for `claude-agent-acp` (file system, child_process for Claude CLI resolution if used, timers).
-
-### Exit criteria (must all pass)
-
-- Full session works through Worker + MessagePort transport in packaged mode.
-- Transport adapter is no larger than Spike 2's (reusing the MessagePort bridge).
-- Worker survives a **deliberately-injected library failure** (e.g. throw in the agent's prompt handler) without taking down the main process — this is the isolation claim being tested.
-- No regression in pending-diff streaming or `acp/resume-session`.
-- Worker entrypoint loads cleanly from packaged app (likely from `app.asar`, but verify).
-
-### What we'd learn
-
-- Does worker-thread isolation actually contain the failure modes we'd worry about in C? (If the answer is "no, the library's failures crash the parent regardless," D collapses into C.)
-- Is D's transport+packaging cost genuinely lighter than A's, or roughly equivalent?
-- Joint with Spikes 1 and 2: the full spectrum of "how much isolation buys how much complexity."
-
-### Rollback
-
-Spike runs on a branch; no production paths touched.
-
 ## What We Explicitly Defer
 
-- **Option B spikes** — only attempt if all of A, C, D fail their exit criteria. Research (R5, R6) runs only if B becomes a live contender.
-- **Option E (re-enable `RunAsNode`)** — security-posture regression, no gain over A/B/D.
+- **Option D (`worker_threads`)** — deferred. Workers share the parent OS process, so they do not isolate the watcher fd pressure R4 identified. Sync-crash containment is D's only remaining hedge and is not a flagged risk.
+- **Option B spikes** — only attempt if A and C both fail their exit criteria. Research (R5) runs only if B becomes a live contender. If B opens, prefer the bundled-Node-runtime + JS-entrypoint variant (Zed precedent, R1). Bun and Node SEA are not priority variants.
+- **Option E (re-enable `RunAsNode`)** — security-posture regression, no gain over A/C/B.
 - **Option F (external tooling prerequisite)** — already ruled out by self-containment direction.
 
-## Decision Framework (after research + spikes)
+## Decision Framework (after spikes)
 
-Apply in order:
+R1–R4 research is complete. Apply in order:
 
-1. **All three spikes pass their exit criteria** → choose on research precedent (R1, R2) plus isolation need.
-   - If mature ACP-hosting apps embed in-process → pick C (simplest; precedent supports it).
-   - If they subprocess via OS-level isolation → pick A.
-   - If we want isolation but can't justify A's packaging cost and D contained the injected-failure test → pick D.
-   - Absent clear precedent, default to **C** (fewest moving parts).
-2. **C fails but A and/or D pass** → compare A vs D on cost. Prefer D if its adapter is meaningfully smaller and its isolation claim held; otherwise A.
-3. **Only C passes** → pick C. Accept the process-boundary tradeoff; the spike proved the library behaves.
-4. **Only A passes** → pick A. Pay the transport+packaging cost for hard isolation.
-5. **Only D passes** → pick D. (Implies C's library behavior is fragile in main-thread hosting but survives in a worker, and A's packaging is prohibitive — a narrow but possible outcome.)
-6. **None pass** → re-open B with R5/R6 research; pick the variant with the lightest release-toolchain impact.
+1. **Spike 1 (A) passes its exit criteria** → pick A. R1 establishes subprocess-with-embedded-runtime as the production precedent (Zed); `utilityProcess` is Electron's native equivalent. Ship.
+2. **Spike 1 fails, Spike 2 (C) passes** → pick C. Accept the loss of OS-process isolation; the spike proved the library behaves in main-process hosting and fd pressure is within a documented ceiling.
+3. **Both fail** → re-open B. Run R5 research on bundled-Node-runtime packaging mechanics; pick that variant (not Bun or SEA).
 
 ## Estimated Effort
 
-- Research: ~2–4 hours focused reading (R1–R4 is the required block).
-- Spike 1 (C): ~1 day — POC already exists; hardening and packaged verification is the work.
-- Spike 2 (A): ~1–2 days — transport adapter is the unknown; packaging questions add variance.
-- Spike 3 (D): ~0.5–1 day — transport adapter reuses Spike 2's; the incremental work is the Worker bootstrap and the injected-failure isolation test.
+- Research: complete (R1–R4 done).
+- Spike 1 (A): ~1–2 days — transport adapter is the unknown; packaging questions add variance.
+- Spike 2 (C): ~1 day — POC already exists; hardening and packaged verification is the work. Only runs if Spike 1 fails.
 
-**Sequencing note:** run Spike 2 before Spike 3 so the MessagePort transport adapter is already built; Spike 3 then tests the "same transport, different host" hypothesis with minimal added cost.
+**Sequencing note:** run Spike 1 (A) first, standalone. If it passes, stop. If it fails, run Spike 2 (C).
 
 ## Critical Files
 
-- [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) — current subprocess launch site; all spikes modify or guard this.
+- [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) — current subprocess launch site; both spikes modify or guard this.
 - [src/gremllm/main/effects/acp.cljs](/Users/paul/Projects/gremllm/src/gremllm/main/effects/acp.cljs) — ACP connection lifecycle; bridges Clojure side to the JS bridge.
-- [forge.config.js](/Users/paul/Projects/gremllm/forge.config.js) — packaging config; Spike 2 may need `asarUnpack` entries.
-- [src/gremllm/main/core.cljs](/Users/paul/Projects/gremllm/src/gremllm/main/core.cljs) — ACP init site; the "eager init at boot" behavior matters for all spikes' verification.
+- [forge.config.js](/Users/paul/Projects/gremllm/forge.config.js) — packaging config; Spike 1 (A) may need `asarUnpack` entries for the utility-process entrypoint and/or vendored CLI.
+- [src/gremllm/main/core.cljs](/Users/paul/Projects/gremllm/src/gremllm/main/core.cljs) — ACP init site; the "eager init at boot" behavior matters for both spikes' verification.
 
 ## Verification
 
@@ -236,5 +194,5 @@ After the chosen option is implemented:
 
 - Run `npm run dev` — full session with document.md edit proposal, accept, resume.
 - Run `npm run make`; install `/Applications/Gremllm.app`; launch from Finder (clean PATH); run full session.
-- `fs_usage` or `lsof` check during a 10-prompt session to confirm no fd leak.
+- `fs_usage` or `lsof` check across multiple full sessions (create + tear down) to confirm no fd leak. Watcher lifecycle is per-session; per-prompt checks are insufficient.
 - Uninstall Homebrew Node temporarily; re-verify packaged launch works (proves no implicit host-tooling dependency).

--- a/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md
+++ b/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md
@@ -1,0 +1,240 @@
+# Plan: Research and Spikes for ACP Packaged-App Agent Launch
+
+**Date:** 2026-04-20
+**Status:** Proposed
+**Input spec:** [docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md](/Users/paul/Projects/gremllm/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md)
+
+## Context
+
+The investigation spec enumerated six options (A–F) for fixing the packaged-app `spawn npx ENOENT` failure. We need an evidence-based decision, but only C has a local POC and only B has concrete variants documented — the rest are docs-only. This plan closes those gaps by:
+
+1. **Web research** to surface real-world precedent and de-risk unknowns before committing engineering time.
+2. **Three spikes** to validate the top candidates (C, A, D) against real packaged-app behavior, not sandbox probes.
+
+User priors (from brainstorming):
+
+- Hard OS-process boundary: **strong preference, not a hard requirement** — willing to accept in-process if the ACP library is well-behaved and A's transport cost is material.
+- Release-toolchain additions: **open, pending research** — whether adding Bun or a bundled Node runtime is worth it depends on what other Electron agent apps actually ship.
+- Decision factors are **all of: library behavior (C), transport-rewrite cost (A), real-world precedent (research)** — multi-factor, not binary.
+
+Viable set going in: **A (utilityProcess)**, **B (packaged launcher)**, **C (in-process)**, **D (worker thread)**.
+Eliminated: E (security regression), F (not self-contained).
+
+## Web Research Items
+
+Ordered by expected decision-shaping value. Each item has an explicit "what this tells us" so we can stop when the evidence converges.
+
+### R1. Zed's own packaging of ACP agents *(highest value)*
+
+Zed originated ACP. Their open-source repo shows exactly how a production app launches `claude-agent-acp` and peers. This is the single most informative data point.
+
+**Questions to answer:**
+- How does Zed resolve the agent binary in a packaged build — bundled, downloaded on first run, user-provided?
+- Do they subprocess or embed? If subprocess, how do they locate the runtime?
+- Do they ship Node/Bun, or assume system Node?
+
+**Tells us:** baseline precedent from the protocol's authors; sanity-check on whether in-process hosting is viable at all.
+
+### R2. Other Electron-based agent apps
+
+Cursor, Continue, Windsurf, Cline. How do they ship their agent runtime?
+
+**Questions:**
+- Do any of them subprocess an agent that speaks a bidirectional protocol (ACP / MCP / custom)? If so, via what mechanism — `utilityProcess`, `execFile` of bundled runtime, something else?
+- Any of them embed the agent library in-process?
+- Anyone shipping a Bun-compiled helper?
+
+**Tells us:** what the "obvious" answer is in this product space; whether B variants have real traction.
+
+### R3. `utilityProcess` + bidirectional stream patterns
+
+Electron's `utilityProcess` fixes stdin to `ignore`. Before committing to Spike A, verify the workaround pattern exists and is clean.
+
+**Questions:**
+- Is there a documented or community pattern for NDJSON over `MessagePort` with `utilityProcess`?
+- Can the ACP SDK's `ReadableStream` / `WritableStream` transport accept a MessagePort adapter cleanly?
+- Any known gotchas with loading a `utilityProcess` entrypoint from inside `app.asar`?
+
+**Tells us:** whether Spike A's transport bridge is a known-solved problem or an open research question. If the latter, the spike's cost estimate goes up.
+
+### R4. `claude-agent-acp` EMFILE / settings-watcher origin
+
+The local POC surfaced `EMFILE` settings-watcher warnings. Identify the source before Spike C so the spike has a clean signal.
+
+**Questions:**
+- What in the published `@agentclientprotocol/claude-agent-acp` (or transitively in `@anthropic-ai/claude-agent-sdk`) starts a file watcher at import/construction time?
+- Is there a documented way to disable the watcher, or an env var / option?
+- Is this a known issue upstream?
+
+**Tells us:** whether the warning is a sandbox artifact we can ignore, or a real integration concern that affects C's viability.
+
+### R5. Bun single-file executable: macOS signing/notarization track record
+
+Only matters if research lands us on B.
+
+**Questions:**
+- Do signed/notarized macOS apps successfully ship Bun-compiled helpers today?
+- Hardened runtime compatibility?
+- Artifact size implications?
+
+**Tells us:** whether B's Bun variant is production-realistic or still has rough edges.
+
+### R6. Node SEA maturity for ESM packages (2026)
+
+Same scope: only matters if B becomes serious and Bun is ruled out.
+
+**Tells us:** whether the SEA variant of B is worth even considering, or still blocked by the CJS-only limitation the spec noted.
+
+**Research stop condition:** when R1–R4 converge on a direction, stop. R5–R6 only run if B becomes a contender.
+
+## Spike 1: Harden In-Process ACP (Option C)
+
+### Goal
+
+Determine whether in-process hosting is production-viable, or whether the POC's clean result was a sandbox artifact that won't survive a real packaged-app session.
+
+### Hypothesis being tested
+
+> `claude-agent-acp` can run inside Electron's main process (via `ClaudeAcpAgent` + `AgentSideConnection` + paired `TransformStream`s) for a full real session without fd leaks, event-loop pauses, or environment-assumption failures.
+
+### Scope
+
+1. Build a minimal main-process ACP host using the already-proven POC shape: `ClientSideConnection` ↔ paired `TransformStream`s ↔ `AgentSideConnection` ↔ `ClaudeAcpAgent`.
+2. Wire it behind a feature flag in [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) so dev mode can toggle between subprocess and in-process.
+3. Verify dev mode first: real session with document.md read, pending-diff streaming, multi-turn, resume-session.
+4. Verify packaged mode: install to `/Applications`, launch from Finder, run the same session end-to-end.
+5. Identify EMFILE origin using R4's findings.
+
+### Exit criteria (must all pass)
+
+- Clean session ≥10 minutes of real document work; no crashes, no event-loop stalls.
+- EMFILE warning root cause identified and either eliminated or documented as benign.
+- No regression in pending-diff rendering (`schema.codec` normalization still produces correct shape).
+- `acp/resume-session` works across app restarts in packaged mode.
+- fd count stable across 10+ prompts (no leak).
+
+### What we'd learn
+
+- Is C the simplest viable path? (prior: yes)
+- If it fails, what's the blocker: library environment assumptions, runtime fragility, or process-model mismatch? That failure mode informs whether A or B is the fallback.
+
+### Rollback
+
+Feature flag defaults off; subprocess path remains untouched.
+
+## Spike 2: `utilityProcess`-Hosted ACP (Option A)
+
+### Goal
+
+Determine the real transport-rewrite cost of A, and whether `utilityProcess`'s stdin-ignore constraint is prohibitive in practice.
+
+### Hypothesis being tested
+
+> A `utilityProcess` entrypoint hosting `ClaudeAcpAgent` can bridge its NDJSON streams to `MessagePort` messages with a transport adapter small enough (≤~100 lines) that A's incremental cost over C is worth paying for the process-isolation benefit.
+
+### Scope
+
+1. Create a packaged child entrypoint (JS) that constructs `ClaudeAcpAgent` and exposes its ACP transport as a MessagePort-backed stream pair.
+2. `utilityProcess.fork()` it from the main process; set up MessagePort.
+3. Adapt the main-process ACP client to feed `ClientSideConnection` a `ReadableStream`/`WritableStream` pair that reads/writes MessagePort messages instead of stdin/stdout bytes.
+4. Verify the same end-to-end behavior as Spike 1's exit criteria.
+5. Decide empirically whether the utility-process entrypoint loads from `app.asar` or needs `asarUnpack`.
+
+### Exit criteria (must all pass)
+
+- Full session works through MessagePort transport in packaged mode.
+- Transport adapter ≤ ~100 lines total (main side + child side). This is the **cost bound** — if it blows past, "low transport cost" is falsified and the spike tells us to prefer C.
+- Utility-process child survives parent-process signals correctly (clean shutdown, restart).
+- Asar-loading question has a definitive answer (works / needs unpack / needs bundling step).
+
+### What we'd learn
+
+- The real answer to "is A a meaningful rewrite, or a clean refactor?"
+- Whether Electron's officially-recommended primitive fits the ACP bridge shape.
+- Joint with Spike 1's result: the actual A-vs-C comparison, evidence-based.
+
+### Rollback
+
+Spike runs on a branch; no production paths touched until a decision is made.
+
+## Spike 3: `worker_threads`-Hosted ACP (Option D)
+
+### Goal
+
+Determine whether a worker-thread host provides meaningful isolation (crash containment for ordinary JS failures, CPU isolation) at lower transport and packaging cost than Option A, while avoiding main-process coupling that Option C accepts.
+
+### Hypothesis being tested
+
+> A `worker_threads` Worker hosting `ClaudeAcpAgent` delivers enough isolation from the Electron main process to contain ordinary library failures, and its `MessagePort` transport is cheaper to build than `utilityProcess`'s (because Worker integrates more natively with Node streams and loads JS directly without the packaged-entrypoint questions `utilityProcess` raises).
+
+### Scope
+
+1. Create a Worker entrypoint that constructs `ClaudeAcpAgent` and exposes its ACP transport over the Worker's `parentPort`.
+2. Main process spawns the Worker via `new Worker(...)` and adapts `ClientSideConnection` to read/write through `MessagePort`.
+3. Reuse as much of Spike 2's transport-adapter code as possible — the `MessagePort` ↔ `ReadableStream`/`WritableStream` bridge is the same shape.
+4. Verify the same end-to-end exit criteria as Spike 1 in packaged mode.
+5. Confirm Electron's embedded Node in the main process gives the Worker a Node environment sufficient for `claude-agent-acp` (file system, child_process for Claude CLI resolution if used, timers).
+
+### Exit criteria (must all pass)
+
+- Full session works through Worker + MessagePort transport in packaged mode.
+- Transport adapter is no larger than Spike 2's (reusing the MessagePort bridge).
+- Worker survives a **deliberately-injected library failure** (e.g. throw in the agent's prompt handler) without taking down the main process — this is the isolation claim being tested.
+- No regression in pending-diff streaming or `acp/resume-session`.
+- Worker entrypoint loads cleanly from packaged app (likely from `app.asar`, but verify).
+
+### What we'd learn
+
+- Does worker-thread isolation actually contain the failure modes we'd worry about in C? (If the answer is "no, the library's failures crash the parent regardless," D collapses into C.)
+- Is D's transport+packaging cost genuinely lighter than A's, or roughly equivalent?
+- Joint with Spikes 1 and 2: the full spectrum of "how much isolation buys how much complexity."
+
+### Rollback
+
+Spike runs on a branch; no production paths touched.
+
+## What We Explicitly Defer
+
+- **Option B spikes** — only attempt if all of A, C, D fail their exit criteria. Research (R5, R6) runs only if B becomes a live contender.
+- **Option E (re-enable `RunAsNode`)** — security-posture regression, no gain over A/B/D.
+- **Option F (external tooling prerequisite)** — already ruled out by self-containment direction.
+
+## Decision Framework (after research + spikes)
+
+Apply in order:
+
+1. **All three spikes pass their exit criteria** → choose on research precedent (R1, R2) plus isolation need.
+   - If mature ACP-hosting apps embed in-process → pick C (simplest; precedent supports it).
+   - If they subprocess via OS-level isolation → pick A.
+   - If we want isolation but can't justify A's packaging cost and D contained the injected-failure test → pick D.
+   - Absent clear precedent, default to **C** (fewest moving parts).
+2. **C fails but A and/or D pass** → compare A vs D on cost. Prefer D if its adapter is meaningfully smaller and its isolation claim held; otherwise A.
+3. **Only C passes** → pick C. Accept the process-boundary tradeoff; the spike proved the library behaves.
+4. **Only A passes** → pick A. Pay the transport+packaging cost for hard isolation.
+5. **Only D passes** → pick D. (Implies C's library behavior is fragile in main-thread hosting but survives in a worker, and A's packaging is prohibitive — a narrow but possible outcome.)
+6. **None pass** → re-open B with R5/R6 research; pick the variant with the lightest release-toolchain impact.
+
+## Estimated Effort
+
+- Research: ~2–4 hours focused reading (R1–R4 is the required block).
+- Spike 1 (C): ~1 day — POC already exists; hardening and packaged verification is the work.
+- Spike 2 (A): ~1–2 days — transport adapter is the unknown; packaging questions add variance.
+- Spike 3 (D): ~0.5–1 day — transport adapter reuses Spike 2's; the incremental work is the Worker bootstrap and the injected-failure isolation test.
+
+**Sequencing note:** run Spike 2 before Spike 3 so the MessagePort transport adapter is already built; Spike 3 then tests the "same transport, different host" hypothesis with minimal added cost.
+
+## Critical Files
+
+- [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) — current subprocess launch site; all spikes modify or guard this.
+- [src/gremllm/main/effects/acp.cljs](/Users/paul/Projects/gremllm/src/gremllm/main/effects/acp.cljs) — ACP connection lifecycle; bridges Clojure side to the JS bridge.
+- [forge.config.js](/Users/paul/Projects/gremllm/forge.config.js) — packaging config; Spike 2 may need `asarUnpack` entries.
+- [src/gremllm/main/core.cljs](/Users/paul/Projects/gremllm/src/gremllm/main/core.cljs) — ACP init site; the "eager init at boot" behavior matters for all spikes' verification.
+
+## Verification
+
+After the chosen option is implemented:
+
+- Run `npm run dev` — full session with document.md edit proposal, accept, resume.
+- Run `npm run make`; install `/Applications/Gremllm.app`; launch from Finder (clean PATH); run full session.
+- `fs_usage` or `lsof` check during a 10-prompt session to confirm no fd leak.
+- Uninstall Homebrew Node temporarily; re-verify packaged launch works (proves no implicit host-tooling dependency).

--- a/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md
+++ b/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md
@@ -1,7 +1,7 @@
 # Plan: Research and Spikes for ACP Packaged-App Agent Launch
 
 **Date:** 2026-04-20
-**Status:** Updated post R1–R4 research
+**Status:** Updated post R1–R4 research and primary-source review of `claude-agent-acp@0.29.2`
 **Input spec:** [docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md](/Users/paul/Projects/gremllm/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md)
 
 ## Context
@@ -9,15 +9,27 @@
 The investigation spec enumerated six options (A–F) for fixing the packaged-app `spawn npx ENOENT` failure. We need an evidence-based decision, but only C has a local POC and only B has concrete variants documented — the rest are docs-only. This plan closes those gaps by:
 
 1. **Web research** to surface real-world precedent and de-risk unknowns before committing engineering time.
-2. **Two spikes** to validate the top candidates (A, then C as fallback) against real packaged-app behavior, not sandbox probes.
+2. **Two spikes** to validate the top candidates against real packaged-app behavior, not sandbox probes.
 
 User priors (from brainstorming):
 
-- Hard OS-process boundary: **strong preference, not a hard requirement** — willing to accept in-process if the ACP library is well-behaved and A's transport cost is material.
+- Hard OS-process boundary: **strong preference, not a hard requirement** — willing to accept in-process if the ACP library is well-behaved.
 - Release-toolchain additions: **open, pending research** — whether adding Bun or a bundled Node runtime is worth it depends on what other Electron agent apps actually ship.
-- Decision factors are **all of: library behavior (C), transport-rewrite cost (A), real-world precedent (research)** — multi-factor, not binary.
+- Decision factors are **all of: library behavior (C), runtime-resolution story, real-world precedent (research)** — multi-factor, not binary.
 
-Viable set after R1–R4: **A (utilityProcess)**, **C (in-process)**. B held in reserve.
+### Reframing: runtime resolution is the first gate, not host model
+
+Primary-source review of the pinned adapter revealed that `claude-agent-acp@0.29.2` hardcodes `executable: isStaticBinary() ? undefined : process.execPath` when constructing its Claude Code SDK query (`node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1133`). In a packaged Electron app with the Fuse `RunAsNode: false` (see `forge.config.js:41`), `process.execPath` resolves to the Gremllm Electron binary, which refuses to run arbitrary JS. A `utilityProcess` child inherits the same `process.execPath` — so **Option A does not solve runtime resolution; it inherits the same failure mode as today's broken code**.
+
+Override surface in the pinned adapter:
+- `CLAUDE_CODE_EXECUTABLE` env → sets `pathToClaudeCodeExecutable` (`acp-agent.js:1134-1135`). Points at the *target* JS entry; still needs a runtime.
+- `CLAUDE_AGENT_ACP_IS_SINGLE_FILE_BUN` env → triggers `isStaticBinary()` branch (`acp-agent.js:38-44`), which leaves `executable` undefined and uses `@anthropic-ai/claude-agent-sdk/embed` as the CLI path (precompiled single-file binary).
+- In-code comment at `acp-agent.js:1131-1132` documents that `executable` accepts an absolute path: "passing an absolute path here works to find Zed's managed node version." This is Zed's documented-in-code pattern for packaged runtime control.
+- `settingSources: ["user","project","local"]` at `acp-agent.js:1112` is spread *before* `...userProvidedOptions`, so a caller-provided `_meta.claudeCode.options.settingSources: []` overrides it — useful for reducing SDK-side watcher pressure during the spike.
+
+**Consequence for the plan:** the A-vs-C host-model question is secondary to the runtime-resolution question. Both A and C must resolve the same underlying problem ("what interpreter runs Claude Code CLI in our packaged app"). C is the simpler substrate to probe that question on, and the POC already works at the library-integration layer.
+
+Viable set after research and primary-source review: **C (in-process)** as the lead substrate, **A (utilityProcess)** as the fallback if C's library behavior is unacceptable in main. B enters the picture if *runtime resolution* itself proves unsolvable in-Electron.
 Dropped during research: D (workers share parent OS process — no fd isolation, only sync crash containment; not a flagged risk).
 Eliminated: E (security regression), F (not self-contained).
 
@@ -79,13 +91,71 @@ Only if B is reopened. R1 establishes this sub-variant (Zed's managed-Node-runti
 
 **Tells us:** whether the bundled-Node B variant is production-realistic as a fallback if A and C both fail.
 
-**Research stop condition:** when R1–R4 converge on a direction, stop. R5 only runs if B becomes a contender.
+### R6. `claude-agent-acp` runtime-resolution surface *(primary-source, already reviewed)*
 
-## Spike 1: `utilityProcess`-Hosted ACP (Option A) *(run first)*
+Review of the pinned `claude-agent-acp@0.29.2` source established the `executable: process.execPath` hardcoding, the `CLAUDE_CODE_EXECUTABLE` / `CLAUDE_AGENT_ACP_IS_SINGLE_FILE_BUN` override envs, the `settingSources` override path, and the in-code Zed-managed-Node pattern comment. See Context reframing above. No further web research needed on this item before Spike 1 — the spike itself produces the empirical runtime-resolution answer.
+
+**Tells us:** the override surface we have available. Shapes Spike 1's first step.
+
+**Research stop condition:** when R1–R4 converge on a direction, stop. R5 only runs if B becomes a contender. R6 is already complete.
+
+## Spike 1: Harden In-Process ACP (Option C) *(run first)*
 
 ### Goal
 
-Determine the real transport-rewrite cost of A, and whether `utilityProcess`'s stdin-ignore constraint is prohibitive in practice. R1 (Zed) establishes subprocess-with-embedded-runtime as the production precedent for ACP agent hosting; this spike validates that Electron's native subprocess primitive fits the shape.
+Answer two questions the plan cannot resolve from code-reading alone:
+
+1. **Runtime resolution:** what override makes `claude-agent-acp`'s internal Claude Code CLI launch succeed in a packaged Electron app where `process.execPath` is the Electron binary and `RunAsNode` is fused off?
+2. **Main-process hosting stability:** once runtime resolution is solved, does the adapter library behave well in Electron's main process for full real sessions?
+
+The POC already cleared the library-integration layer; the unknowns are packaged-runtime resolution and long-session stability.
+
+### Hypothesis being tested
+
+> With a suitable `executable` / `pathToClaudeCodeExecutable` / `isStaticBinary` override strategy, `claude-agent-acp` can run inside Electron's main process (via `ClaudeAcpAgent` + `AgentSideConnection` + paired `TransformStream`s) for a full real session without fd leaks, event-loop pauses, or environment-assumption failures.
+
+### Scope
+
+1. **Runtime-resolution probe (first, before any host wiring).** In packaged mode, reproduce the default `spawn` failure and capture the exact executable/args the adapter attempts. Enumerate the override strategies available from `acp-agent.js:1133-1138`:
+   - `CLAUDE_CODE_EXECUTABLE=<path>` pointing at a resolvable JS entry (still needs an interpreter — only useful if combined with strategy 2 or 3).
+   - `executable=<absolute path to Node>` (Zed's documented-in-code pattern at `acp-agent.js:1131-1132`; requires bundling Node, B-adjacent).
+   - `CLAUDE_AGENT_ACP_IS_SINGLE_FILE_BUN=1` + `@anthropic-ai/claude-agent-sdk/embed` (precompiled single-file binary; verify the pinned `@anthropic-ai/claude-agent-sdk` version ships this `embed` entry).
+   Pick the lowest-effort strategy that works; document the decision.
+2. Build a minimal main-process ACP host using the POC shape: `ClientSideConnection` ↔ paired `TransformStream`s ↔ `AgentSideConnection` ↔ `ClaudeAcpAgent`.
+3. Wire it behind a feature flag in [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) so dev mode can toggle between subprocess and in-process; default off until the spike passes.
+4. Reduce nondeterminism during the spike by passing `settingSources: []` via `_meta.claudeCode.options` — `acp-agent.js:1112` spreads `userProvidedOptions` after the default, so this override lands. Removes SDK-side filesystem watcher load; the adapter's own `SettingsManager` watchers (`settings.js:153`) remain.
+5. Verify `claude-agent-acp` PR #454 (watcher leak fix) is present in pinned `0.29.2`; patch or upgrade if not.
+6. Verify dev mode: real session with `document.md` read, pending-diff streaming, multi-turn, resume-session.
+7. Verify packaged mode: install to `/Applications`, launch from Finder, run the same session end-to-end.
+
+### Exit criteria (must all pass)
+
+- **Runtime resolution:** a named override strategy makes the packaged launch succeed end-to-end, with the exact config captured in the spike notes (env vars, resource paths, `asarUnpack` entries).
+- Clean session ≥10 minutes of real document work; no crashes, no event-loop stalls.
+- Watcher fd ceiling measured: known origin (adapter `SettingsManager` + SDK settings), known lifecycle (per-session create/dispose), documented bound.
+- fd count stable across **N full sessions** (create + tear down cycle), not just N prompts within one session.
+- No regression in pending-diff rendering (`schema.codec` normalization still produces correct shape).
+- `acp/resume-session` works across app restarts in packaged mode.
+
+### What we'd learn
+
+- Whether a single override flag (likely `isStaticBinary` or a bundled Node + `executable` path) unblocks packaged launch, and what packaging/`asarUnpack` entries that strategy requires.
+- Whether main-process hosting is stable enough to ship. If yes → pick C and stop.
+- **Failure-mode routing for the next step:**
+  - If runtime resolution itself proves unsolvable in-Electron → pivot to **Option B** (explicit runtime control: bundled Node, or static Claude binary). **Not Spike 2 (A)** — A inherits the same `process.execPath` problem.
+  - If runtime resolution works but main-process hosting is unacceptable (event-loop pauses, fd pressure past PR #454) → **then** run Spike 2 (A) for the OS-process isolation it provides.
+
+### Rollback
+
+Feature flag defaults off; subprocess path remains untouched.
+
+## Spike 2: `utilityProcess`-Hosted ACP (Option A) *(run only if Spike 1 fails on main-process library stability, not on runtime resolution)*
+
+### Goal
+
+Determine whether moving the adapter out of the main process (into a `utilityProcess` child) provides enough isolation value to justify the transport-adapter cost, *given* that Spike 1 already solved runtime resolution.
+
+Note: this spike is only worth running if Spike 1 revealed unacceptable main-process library behavior. A `utilityProcess` child inherits the same `process.execPath` as the parent (`acp-agent.js:1133`), so it does not by itself solve packaged runtime resolution — Spike 1's override strategy is a prerequisite.
 
 ### Hypothesis being tested
 
@@ -96,96 +166,60 @@ Determine the real transport-rewrite cost of A, and whether `utilityProcess`'s s
 1. Create a packaged child entrypoint (JS) that constructs `ClaudeAcpAgent` and exposes its ACP transport as a MessagePort-backed stream pair.
 2. `utilityProcess.fork()` it from the main process; set up MessagePort.
 3. Adapt the main-process ACP client to feed `ClientSideConnection` a `ReadableStream`/`WritableStream` pair that reads/writes MessagePort messages instead of stdin/stdout bytes.
-4. Verify dev mode first: real session with document.md read, pending-diff streaming, multi-turn, resume-session.
-5. Verify packaged mode: install to `/Applications`, launch from Finder, run the same session end-to-end.
-6. Determine empirically whether the utility-process entrypoint loads from `app.asar` or needs `asarUnpack`.
-7. Expose a `CLAUDE_AGENT_ACP_EXECUTABLE`-style env override for local dev/debug (analogous to Zed's `CLAUDE_CODE_EXECUTABLE`).
+4. Apply Spike 1's runtime-resolution override strategy inside the child entrypoint (same `executable` / env fix, now in the child context).
+5. Verify dev mode first: real session with document.md read, pending-diff streaming, multi-turn, resume-session.
+6. Verify packaged mode: install to `/Applications`, launch from Finder, run the same session end-to-end.
+7. Determine empirically whether the utility-process entrypoint loads from `app.asar` or needs `asarUnpack`.
 
 ### Exit criteria (must all pass)
 
 - Full session works through MessagePort transport in packaged mode.
-- Transport adapter ≤~100 lines total (main side + child side). This is the **cost bound** — if it blows past, "low transport cost" is falsified and the spike tells us to prefer C.
+- Transport adapter ≤~100 lines total (main side + child side). This is the **cost bound** — if it blows past, "low transport cost" is falsified.
 - Utility-process child survives parent-process signals correctly (clean shutdown, restart).
 - Asar-loading question has a definitive answer (works / needs unpack / needs bundling step).
 - No regression in pending-diff rendering (`schema.codec` normalization still produces correct shape).
 - `acp/resume-session` works across app restarts in packaged mode.
-- Adapter-internal Claude Code CLI subprocess launches correctly in packaged mode; `asarUnpack` need for the vendored CLI determined.
 
 ### What we'd learn
 
 - The real answer to "is A a meaningful rewrite, or a clean refactor?"
-- Whether Electron's officially-recommended primitive fits the ACP bridge shape.
+- Whether Electron's officially-recommended primitive fits the ACP bridge shape once runtime resolution is already in hand.
 - If A passes, we ship — no further spikes needed.
 
 ### Rollback
 
 Spike runs on a branch; no production paths touched until a decision is made.
 
-## Spike 2: Harden In-Process ACP (Option C) *(fallback — run only if Spike 1 fails)*
-
-### Goal
-
-Determine whether in-process hosting is production-viable, or whether the POC's clean result was a sandbox artifact that won't survive a real packaged-app session.
-
-### Hypothesis being tested
-
-> `claude-agent-acp` can run inside Electron's main process (via `ClaudeAcpAgent` + `AgentSideConnection` + paired `TransformStream`s) for a full real session without fd leaks, event-loop pauses, or environment-assumption failures.
-
-### Scope
-
-1. Build a minimal main-process ACP host using the already-proven POC shape: `ClientSideConnection` ↔ paired `TransformStream`s ↔ `AgentSideConnection` ↔ `ClaudeAcpAgent`.
-2. Wire it behind a feature flag in [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) so dev mode can toggle between subprocess and in-process.
-3. Verify dev mode first: real session with document.md read, pending-diff streaming, multi-turn, resume-session.
-4. Verify packaged mode: install to `/Applications`, launch from Finder, run the same session end-to-end.
-5. Verify `claude-agent-acp` PR #454 (watcher leak fix) is present in the bundled version; patch or upgrade if not.
-6. Confirm adapter-internal Claude Code CLI subprocess launches correctly in packaged mode (same asar concern as Spike 1).
-
-### Exit criteria (must all pass)
-
-- Clean session ≥10 minutes of real document work; no crashes, no event-loop stalls.
-- EMFILE warning root cause identified (per R4: per-session `SettingsManager` watchers + SDK `settingSources` watchers) and either eliminated or documented as stable with a measured ceiling.
-- fd count stable across **N full sessions** (create + tear down cycle), not just N prompts within one session. Watcher lifecycle is per-session; this is the correct signal.
-- No regression in pending-diff rendering (`schema.codec` normalization still produces correct shape).
-- `acp/resume-session` works across app restarts in packaged mode.
-- Adapter-internal Claude Code CLI subprocess launches correctly in packaged mode; `asarUnpack` need for the vendored CLI determined.
-
-### What we'd learn
-
-- Is C production-viable as a fallback? If yes, and A's transport adapter exceeded its cost bound, pick C.
-- Failure mode shapes the B decision: library environment assumptions → B likely needed; runtime fragility → B still needed; watcher fd exhaustion → document ceiling and accept.
-
-### Rollback
-
-Feature flag defaults off; subprocess path remains untouched.
-
 ## What We Explicitly Defer
 
-- **Option D (`worker_threads`)** — deferred. Workers share the parent OS process, so they do not isolate the watcher fd pressure R4 identified. Sync-crash containment is D's only remaining hedge and is not a flagged risk.
-- **Option B spikes** — only attempt if A and C both fail their exit criteria. Research (R5) runs only if B becomes a live contender. If B opens, prefer the bundled-Node-runtime + JS-entrypoint variant (Zed precedent, R1). Bun and Node SEA are not priority variants.
+- **Option D (`worker_threads`)** — deferred. Workers share the parent OS process, so they do not isolate the watcher fd pressure R4 identified, and they inherit `process.execPath` the same way `utilityProcess` does, so they do not help runtime resolution either. Sync-crash containment is D's only remaining hedge and is not a flagged risk.
+- **Option B** — now a first-class fallback, not a last resort. Triggered specifically by Spike 1 failing on runtime resolution. If B opens, prefer the bundled-Node-runtime + JS-entrypoint variant (Zed precedent, R1 + in-code comment at `acp-agent.js:1131-1132`). Bun and Node SEA are not priority variants. R5 research runs at that point.
 - **Option E (re-enable `RunAsNode`)** — security-posture regression, no gain over A/C/B.
 - **Option F (external tooling prerequisite)** — already ruled out by self-containment direction.
 
 ## Decision Framework (after spikes)
 
-R1–R4 research is complete. Apply in order:
+R1–R4 research and primary-source review of the pinned adapter are complete. Apply in order:
 
-1. **Spike 1 (A) passes its exit criteria** → pick A. R1 establishes subprocess-with-embedded-runtime as the production precedent (Zed); `utilityProcess` is Electron's native equivalent. Ship.
-2. **Spike 1 fails, Spike 2 (C) passes** → pick C. Accept the loss of OS-process isolation; the spike proved the library behaves in main-process hosting and fd pressure is within a documented ceiling.
-3. **Both fail** → re-open B. Run R5 research on bundled-Node-runtime packaging mechanics; pick that variant (not Bun or SEA).
+1. **Spike 1 (C) passes runtime resolution and main-process stability** → pick C. Ship. Record the exact override strategy (env vars, resource paths, `asarUnpack` entries) as the integration contract.
+2. **Spike 1 passes runtime resolution but fails main-process stability** (event-loop pauses, fd pressure past PR #454's fix, or other library-in-main pathologies) → run Spike 2 (A). The runtime-resolution override strategy from Spike 1 carries over directly; A adds OS-process isolation on top.
+3. **Spike 1 fails runtime resolution** (no override strategy works in a packaged Electron app) → pivot to **Option B** (explicit runtime control: bundled Node runtime + JS entrypoint, or static Claude binary). Run R5 research then. **Do not run Spike 2 (A)** in this branch — A inherits the same `process.execPath` failure mode and cannot rescue runtime resolution on its own.
+
+Retired from the earlier framing: "Zed precedent ⇒ A-first." Zed's precedent supports *managed subprocess + controlled runtime*, which maps to B (runtime control as a first-class axis), not to `utilityProcess` + MessagePort.
 
 ## Estimated Effort
 
-- Research: complete (R1–R4 done).
-- Spike 1 (A): ~1–2 days — transport adapter is the unknown; packaging questions add variance.
-- Spike 2 (C): ~1 day — POC already exists; hardening and packaged verification is the work. Only runs if Spike 1 fails.
+- Research: complete (R1–R4 done; R6 primary-source review done).
+- Spike 1 (C): ~1–2 days — runtime-resolution probe is the new unknown; POC covers library integration; packaged verification adds variance.
+- Spike 2 (A): ~1–2 days — only runs in the "runtime resolution works but main-process hosting is unstable" branch. Transport adapter (~100 line bound) + packaging variance.
 
-**Sequencing note:** run Spike 1 (A) first, standalone. If it passes, stop. If it fails, run Spike 2 (C).
+**Sequencing note:** run Spike 1 (C) first. If it passes on both runtime resolution and stability, stop and ship C. If it fails on stability only, run Spike 2 (A). If it fails on runtime resolution, pivot to B (do not run Spike 2).
 
 ## Critical Files
 
 - [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js) — current subprocess launch site; both spikes modify or guard this.
 - [src/gremllm/main/effects/acp.cljs](/Users/paul/Projects/gremllm/src/gremllm/main/effects/acp.cljs) — ACP connection lifecycle; bridges Clojure side to the JS bridge.
-- [forge.config.js](/Users/paul/Projects/gremllm/forge.config.js) — packaging config; Spike 1 (A) may need `asarUnpack` entries for the utility-process entrypoint and/or vendored CLI.
+- [forge.config.js](/Users/paul/Projects/gremllm/forge.config.js) — packaging config; may need `asarUnpack` entries depending on runtime-resolution strategy chosen in Spike 1.
 - [src/gremllm/main/core.cljs](/Users/paul/Projects/gremllm/src/gremllm/main/core.cljs) — ACP init site; the "eager init at boot" behavior matters for both spikes' verification.
 
 ## Verification

--- a/docs/plans/2026-04-21-spike-in-process-acp-host.md
+++ b/docs/plans/2026-04-21-spike-in-process-acp-host.md
@@ -1,0 +1,87 @@
+# Plan: Spike 2 — In-Process ACP Host (Option C)
+
+**Date:** 2026-04-21
+**Scope:** single spike, isolated in a new worktree, reversible by abandonment.
+**Supersedes (for this spike only):** A-first sequencing in `docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md`.
+
+## Context
+
+Packaged Electron launch fails with `spawn npx ENOENT` because the app runs with no npx/node on PATH. R1–R4 narrowed the viable set to A (`utilityProcess`) and C (in-process). Verifying the pinned adapter source — `node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1133` — exposes the decisive fact: it hardcodes `executable: process.execPath` as the interpreter for Claude Code CLI. With fuse `RunAsNode: false` (`forge.config.js:41`), the Electron binary refuses to run as Node. A `utilityProcess` child inherits the same `process.execPath`, so **A does not solve runtime resolution** — it only moves where the failure surfaces.
+
+That promotes Claude-runtime resolution to the primary gate, demotes A-vs-C host-model framing, and makes C the simpler substrate for probing the real blocker. If C clears runtime resolution and the library behaves in main, we ship C. If C fails on *library stability*, A is the justified fallback. If C fails on *runtime resolution*, the fallback is B (explicit runtime control), not A.
+
+## Goal
+
+Replace the `npx`-spawn path with an in-process ACP host: `ClientSideConnection` ↔ paired `TransformStream`s ↔ `AgentSideConnection` ↔ `ClaudeAcpAgent`, all in the Electron main process. Prove Claude-runtime resolution works in packaged mode or document precisely how it fails.
+
+## Approach
+
+### 1. Isolate the spike
+
+- New worktree (parallel to `feat/packaged-agent-launch`), new branch `spike/acp-in-process`.
+- Replace the subprocess path outright — **no feature flag**. Rollback is "abandon the branch."
+
+### 2. Rewrite `src/js/acp/index.js`
+
+- Remove `spawn`, `buildNpxAgentPackageConfig`, `logConfiguredAgentVersion`, subprocess stdin/stdout wiring.
+- Import `ClaudeAcpAgent` from `@agentclientprotocol/claude-agent-acp` and `AgentSideConnection` from `@agentclientprotocol/sdk`.
+- Build paired NDJSON `TransformStream`s (one for each direction). Feed one pair end to `new acp.ClientSideConnection(() => client, stream)` and the other to `new acp.AgentSideConnection(...)` hosting `new ClaudeAcpAgent(...)`.
+- Return `{ connection, disposeAgent, protocolVersion }`. `disposeAgent` closes streams and calls any explicit teardown the library exposes.
+- **Reuse unchanged:** `src/js/acp/permission.js`, `rememberToolName`, `enrichPermissionParams`, `sessionCwdMap`, the `newSession`/`unstable_resumeSession` interception that records cwd.
+
+### 3. Runtime-resolution probe — run FIRST
+
+Before any other correctness work, run the packaged app and capture what `claude-agent-acp` actually spawns. Known override levers (from adapter source):
+
+- `process.env.CLAUDE_CODE_EXECUTABLE` → sets `pathToClaudeCodeExecutable` (`acp-agent.js:1134`).
+- `process.env.CLAUDE_AGENT_ACP_IS_SINGLE_FILE_BUN` → `isStaticBinary()` path, uses `@anthropic-ai/claude-agent-sdk/embed` (line 43). Requires a single-file Bun build — Option B territory; if this is what's needed, spike fails, pivot to B.
+- `_meta.claudeCode.options.executable` via session params — SDK's public override path (the adapter spreads `...userProvidedOptions` after its own `executable:` default).
+
+Try in order: `CLAUDE_CODE_EXECUTABLE` pointing at a resolved, interpretable Claude CLI entry; if that requires a Node interpreter the packaged app doesn't have, spike fails → B.
+
+### 4. Update `src/gremllm/main/effects/acp.cljs`
+
+- State slot `:subprocess` → `:dispose-agent` (a 0-arity fn returned by the JS module).
+- `shutdown` calls `dispose-agent` instead of `.kill(subprocess "SIGTERM")`. Same handling in both the `:state` and `:initialize-in-flight` branches.
+- `start-connection!`'s `.catch` calls `dispose-agent` on failure.
+- Delete `agent-package-mode` and its `:is-packaged?` argument — dead after the rewrite.
+
+### 5. Opportunistically reduce settings-watcher pressure
+
+Pass `settingSources: []` through session `_meta.claudeCode.options` (in `main.actions.acp`'s prompt construction) to disable SDK-side filesystem settings watchers. The adapter's own per-session `SettingsManager` (`dist/settings.js`) is separate and already disposed on teardown — acceptable.
+
+### 6. Forge packaging
+
+- `forge.config.js` starts untouched.
+- Only add `asarUnpack` entries if step 3 empirically shows the Claude CLI asset must live outside asar to be interpretable. Measure, don't pre-optimize.
+
+## Files
+
+- `src/js/acp/index.js` — rewrite (subprocess → in-process).
+- `src/gremllm/main/effects/acp.cljs` — lifecycle + teardown adaptation.
+- `src/gremllm/main/actions/acp.cljs` — add `settingSources: []` to prompt `_meta`.
+- `forge.config.js` — conditional `asarUnpack`, only if measurement demands.
+- `src/js/acp/permission.js` — reused unchanged.
+
+## Verification (exit criteria, in order)
+
+1. **Dev mode:** `npm run dev` — create topic, send prompt, stream reply, `readTextFile` on `document.md`, pending-diff via dry-run `writeTextFile`, multi-turn, resume-session. All green.
+2. **Runtime resolution documented:** precise override that launches Claude Code CLI in packaged mode (or the exact failure signature if none works).
+3. **Packaged launch:** `npm run make`; install `/Applications/Gremllm.app`; launch from Finder in a clean shell; repeat the dev-mode session end-to-end.
+4. **Session fd stability:** create + tear down ≥5 full sessions in the packaged app; `lsof -p <pid>` delta bounded (no monotonic growth). Watcher lifecycle is per-session, so this is the correct signal — per-prompt checks are insufficient.
+5. **Resume across restart:** close the packaged app, relaunch, `acp/resume-session` reattaches.
+6. **Pending-diff regression check:** `schema.codec` normalization + `renderer.ui.document.diffs` still render pending diffs correctly.
+7. **Host-tooling independence:** hide Homebrew Node (`mv /opt/homebrew/bin/node /opt/homebrew/bin/node.hidden`); relaunch packaged app; session still works. Restore after.
+
+## Decision gate (post-spike)
+
+- **All criteria pass →** ship C. Delete `agent-package-mode`, npx-vendor code, this spike's debug overrides. Close A.
+- **Fails at step 2 (runtime resolution) →** pivot to B (bundled Node runtime or static binary). A is not the fallback.
+- **Fails at step 4 (library stability: fd leak beyond PR #454, event-loop pauses) →** A becomes justified. Open Spike 1 carrying the runtime-resolution finding from step 2 forward.
+
+## Explicitly out of scope
+
+- OS-process isolation (requires A).
+- Bundling a Node runtime or static Claude binary (B territory).
+- Renderer, preload, or IPC surface changes — in-process hosting is invisible past `src/js/acp`.
+- Feature flag / subprocess fallback toggle.

--- a/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md
+++ b/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md
@@ -47,11 +47,20 @@ EOF
 spawn npx ENOENT
 ```
 
+- The bundled `@agentclientprotocol/claude-agent-acp` package is not CLI-only. Its published library entrypoint exports `ClaudeAcpAgent`, `runAcp`, and related helpers from `dist/lib.js`.
+- The bundled `@agentclientprotocol/sdk` transport layer is not stdio-specific. `ndJsonStream()` accepts generic Web `ReadableStream` / `WritableStream` pairs, and the SDK's own tests construct client/agent pairs entirely with in-memory `TransformStream`s.
+- A local proof of concept in this repo successfully completed ACP `initialize` and `newSession` in a single Node process using `ClientSideConnection`, `AgentSideConnection`, `ClaudeAcpAgent`, and paired `TransformStream`s. No `npx` or subprocess launch was involved. The probe emitted non-fatal `EMFILE` settings-watcher warnings in this sandbox, but ACP handshake and session creation succeeded.
+- The upstream Anthropic SDK and ACP adapter already contain explicit single-file Bun support surfaces:
+  - `@anthropic-ai/claude-agent-sdk/embed` documents Bun `--compile` usage and extracts the embedded CLI from `$bunfs` so it can be spawned by child processes.
+  - `claude-agent-acp` has a `CLAUDE_AGENT_ACP_IS_SINGLE_FILE_BUN` code path when resolving the Claude CLI.
+
 ## Inference From Evidence
 
 - The packaged app is depending on host installation details for Node/npm tooling, even in `"cached"` mode where the agent package itself is already bundled.
 - Finder / LaunchServices app launches may provide a PATH that does not include Homebrew-installed Node tools. We have not yet logged the actual PATH from the installed app process, but the failure shape is consistent with that environment difference.
 - Even if `npx` happened to exist on the developer machine, treating it as a production runtime dependency is fragile for a signed, packaged desktop app.
+- The in-process ACP path is no longer merely theoretical. The current package set already supports it with the published library API and the existing ACP SDK transport primitives.
+- The "packaged launcher" path is also more concrete than originally stated: at least one upstream-aligned helper-binary approach exists today (single-file Bun), and a "ship your own Node runtime" variant is mechanically possible even if heavier.
 
 ## Scope
 
@@ -78,6 +87,9 @@ References:
 - [Electron app](https://www.electronjs.org/docs/latest/api/app)
 - [Electron process](https://www.electronjs.org/docs/latest/api/process)
 - [Node.js `child_process.spawn()`](https://nodejs.org/download/release/v22.19.0/docs/api/child_process.html)
+- [Node.js worker_threads](https://nodejs.org/download/release/latest-v22.x/docs/api/worker_threads.html)
+- [Node.js Single Executable Applications](https://nodejs.org/download/release/latest-jod/docs/api/single-executable-applications.html)
+- [Bun single-file executables](https://bun.sh/docs/bundler/executables)
 
 ### 1. `spawn()` is PATH-sensitive
 
@@ -144,9 +156,10 @@ Package a concrete agent launcher outside `app.asar` and execute it via `execFil
 
 Examples of what "real launcher" could mean:
 
-- a standalone executable
+- a standalone Bun-compiled executable for the ACP adapter
 - a helper app / helper binary
 - a JS entrypoint plus a packaged runtime capable of executing it
+- a Node single-executable-app wrapper after bundling to a CommonJS entrypoint
 
 ### Advantages
 
@@ -159,6 +172,10 @@ Examples of what "real launcher" could mean:
 - Introduces packaging and distribution complexity.
 - A plain JS file is not enough by itself if there is no reliable runtime to execute it in packaged mode.
 - May require asar unpacking, helper-binary signing, or other release-path special handling.
+- The variants are not equally attractive:
+  - Bun helper: concrete and upstream-aligned, but adds Bun to the release toolchain.
+  - Bundled Node runtime + JS entrypoint: straightforward model-wise, but larger and requires shipping/signing an extra runtime.
+  - Node SEA wrapper: possible in principle, but Node's official SEA docs still describe the embedded app as a single CommonJS script, which is a poor fit for today's ESM `claude-agent-acp` package without an extra bundling layer.
 
 ### Open Technical Unknowns
 
@@ -174,19 +191,45 @@ Stop launching the ACP agent as an external process in packaged mode and instead
 - Eliminates the `npx` / PATH problem entirely.
 - Reuses code that is already bundled in `app.asar`.
 - Avoids subprocess-launch packaging edge cases.
+- Stronger than originally assumed: local evidence shows that ACP handshake and session creation already work with published library APIs and in-memory streams.
+- May require less protocol-layer churn than Option A, because the same ACP SDK `ClientSideConnection` / `AgentSideConnection` types can be reused without stdio.
 
 ### Tradeoffs
 
 - Collapses the current process boundary between Gremllm and the ACP agent.
 - Reduces crash isolation and may complicate resource cleanup.
 - Couples Gremllm more directly to the ACP package's library surface and lifecycle assumptions.
+- Runs agent work on the app-owned runtime unless we combine this with a worker or utility-process host.
+- The local probe surfaced `EMFILE` settings-watcher warnings in this sandbox, which may indicate SDK-side background watchers or may be an artifact of this environment. That needs one more round of validation in the actual app.
 
 ### Open Technical Unknowns
 
 - Whether the package's exported library API is stable and sufficient for this use case without relying on CLI-only behavior.
-- What adapter is needed to replace the current subprocess stdio transport with an in-process connection.
+- Whether the settings-watcher warnings seen in the local probe matter in a real app session.
 
-## Option D: Re-enable `RunAsNode` and Use a Fork-Based Launch
+## Option D: Host `claude-agent-acp` In a Node Worker Thread
+
+Create a dedicated `worker_threads` host for the ACP agent and communicate over `MessagePort` (or a small stream adapter) instead of running the agent directly on the Electron main thread.
+
+### Advantages
+
+- Removes the `npx` / PATH dependency without relaxing the current fuse posture.
+- Keeps the solution entirely inside the app-bundled Node/Electron runtime.
+- Preserves more isolation than main-thread in-process hosting for CPU-heavy work and ordinary JS failures.
+- Uses standard Node primitives that are already available in Electron's main-process runtime.
+
+### Tradeoffs
+
+- Still does not preserve a hard OS process boundary the way `utilityProcess` or `execFile` would.
+- Requires a custom port/stream bridge, similar in spirit to Option A.
+- Introduces worker lifecycle, error-forwarding, and shutdown plumbing that the current design does not need.
+
+### Open Technical Unknowns
+
+- Whether the worker entrypoint should live inside `app.asar` or be unpacked.
+- How much real crash/isolation benefit this buys relative to simply hosting in the main process.
+
+## Option E: Re-enable `RunAsNode` and Use a Fork-Based Launch
 
 Change the fuse policy to allow `RunAsNode` again, then launch a bundled JS agent entrypoint using a Node-style child-process API such as `fork`.
 
@@ -206,14 +249,21 @@ Change the fuse policy to allow `RunAsNode` again, then launch a bundled JS agen
 - Whether the team is willing to relax the current packaged security posture for this functionality.
 - Whether the operational simplicity gain is worth the fuse-policy reversal.
 
-## Option E: Keep `npx`, But Treat Host Node/npm As a Prerequisite
+## Option F: Keep External Node/npm Tooling as a Prerequisite
 
-Retain the current launch path, but detect missing `npx` at startup and show a clear environment error instead of crashing unexpectedly.
+Retain an external-tooling launch path, but treat host Node/npm availability as an explicit prerequisite instead of an implicit assumption.
+
+Variants:
+
+- resolve/import a fuller shell PATH before spawning `npx`
+- detect missing `npx` and surface a clear environment error instead of crashing
+- defer ACP initialization until first ACP use so the whole app does not fail during boot
 
 ### Advantages
 
 - Smallest implementation change.
 - Preserves the current subprocess and ACP transport shape.
+- May be acceptable as a short-term diagnostic or internal-testing bridge while a self-contained launch mode is developed.
 
 ### Tradeoffs
 
@@ -221,6 +271,8 @@ Retain the current launch path, but detect missing `npx` at startup and show a c
 - Keeps startup behavior dependent on PATH and host tool installation.
 - Produces a weaker first-run experience for end users and testers.
 - Leaves production behavior coupled to developer-machine conventions.
+- PATH-import variants reduce one symptom but not the underlying packaging dependency.
+- Lazy init avoids crashing on app boot, but it does not solve the missing-runtime problem.
 
 ### Open Technical Unknowns
 
@@ -228,14 +280,15 @@ Retain the current launch path, but detect missing `npx` at startup and show a c
 
 ## Comparison
 
-| Criterion | A: `utilityProcess` | B: packaged launcher + `execFile` | C: in-process ACP | D: re-enable `RunAsNode` | E: keep `npx` prerequisite |
-|-----------|---------------------|-----------------------------------|-------------------|--------------------------|----------------------------|
-| Removes external PATH dependency | Yes | Yes | Yes | Yes | No |
-| Preserves subprocess boundary | Yes | Yes | No | Yes | Yes |
-| Fits current fuse posture | Yes | Yes | Yes | No | Yes |
-| Requires ACP transport changes | High | Medium | Medium | Low to medium | None |
-| Adds packaging complexity | Medium | High | Low to medium | Medium | Low |
-| Keeps app self-contained | Likely | Likely | Yes | Likely | No |
+| Criterion | A: `utilityProcess` | B: packaged launcher + `execFile` | C: in-process ACP | D: worker thread | E: re-enable `RunAsNode` | F: external tooling prerequisite |
+|-----------|---------------------|-----------------------------------|-------------------|------------------|--------------------------|----------------------------------|
+| Removes external PATH dependency | Yes | Yes | Yes | Yes | Yes | No |
+| Preserves hard process boundary | Yes | Yes | No | No | Yes | Yes |
+| Fits current fuse posture | Yes | Yes | Yes | Yes | No | Yes |
+| Requires ACP transport changes | High | Medium | Low to medium | Medium | Low to medium | None |
+| Adds packaging complexity | Medium | High | Low | Low to medium | Medium | Low |
+| Keeps app self-contained | Likely | Likely | Yes | Yes | Likely | No |
+| Current evidence level | Docs only | Docs + concrete variants | Docs + local POC | Docs only | Docs only | Current broken behavior |
 
 ## Decision Criteria
 
@@ -251,7 +304,9 @@ Any eventual solution should:
 
 - What PATH does the installed app actually see at the point where ACP initialization runs?
 - Can `utilityProcess.fork()` load an entrypoint directly from `app.asar`, or should that script be unpacked?
-- If we pursue a packaged-launcher design, what runtime executes it once `RunAsNode` remains disabled?
+- If we pursue a packaged-launcher design, which concrete variant is best: Bun helper, bundled Node runtime, or something else?
+- Are the `EMFILE` settings-watcher warnings from the in-process probe a sandbox artifact or a real integration concern?
+- Can a worker-thread host give enough isolation to be worthwhile, or is the choice really "main process" versus "real subprocess"?
 - Is preserving a hard process boundary a requirement, or merely a preference carried forward from the current implementation?
 - Is "packaged app is self-contained" a product requirement for this release path, or is an external toolchain prerequisite still considered acceptable?
 
@@ -261,5 +316,6 @@ Before selecting an option, the next round of evidence should ideally answer:
 
 - installed-app runtime PATH logging at ACP init time
 - whether a minimal `utilityProcess` proof of concept can host the agent bridge shape we need
-- whether a packaged absolute-path launcher can be executed cleanly under current fuse and asar constraints
-- whether the in-process ACP library path is viable without depending on unstable internal APIs
+- whether a packaged Bun helper launched via `execFile` works cleanly under signing / asar constraints
+- whether the in-process ACP library path still behaves cleanly when exercised inside the packaged app rather than a standalone Node probe
+- whether a worker-thread host buys enough isolation to justify the extra transport plumbing

--- a/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md
+++ b/docs/specs/2026-04-20-acp-packaged-app-npx-agent-launch-investigation.md
@@ -1,8 +1,9 @@
 # Design: ACP Packaged-App Agent Launch Investigation
 
 **Date:** 2026-04-20
-**Status:** Investigating
+**Status:** Option space narrowed; research and spikes planned
 **Related:** [docs/specs/2026-04-20-acp-packaged-app-bridge-loading-fix-design.md](/Users/paul/Projects/gremllm/docs/specs/2026-04-20-acp-packaged-app-bridge-loading-fix-design.md), [forge.config.js](/Users/paul/Projects/gremllm/forge.config.js), [src/js/acp/index.js](/Users/paul/Projects/gremllm/src/js/acp/index.js)
+**Plan:** [docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md](/Users/paul/Projects/gremllm/docs/plans/2026-04-20-acp-packaged-app-launch-research-spikes.md)
 
 ## Goal
 
@@ -61,6 +62,17 @@ spawn npx ENOENT
 - Even if `npx` happened to exist on the developer machine, treating it as a production runtime dependency is fragile for a signed, packaged desktop app.
 - The in-process ACP path is no longer merely theoretical. The current package set already supports it with the published library API and the existing ACP SDK transport primitives.
 - The "packaged launcher" path is also more concrete than originally stated: at least one upstream-aligned helper-binary approach exists today (single-file Bun), and a "ship your own Node runtime" variant is mechanically possible even if heavier.
+
+## Resolution of Open Questions
+
+The following open questions from this investigation were settled through design review:
+
+- **Is preserving a hard process boundary a requirement, or merely a preference?** Strong preference, not a hard requirement. In-process hosting is acceptable if the ACP library is well-behaved in a real session and a hard-boundary option's transport cost is material.
+- **Is "packaged app is self-contained" a product requirement?** Yes. Option F is ruled out on that basis.
+- **Which concrete launcher variant is best if we pursue Option B?** Deferred pending research. The B-variant question is gated on what other Electron-based agent apps actually ship (web research items R1, R2 in the plan).
+- **Options E and F status:** Both eliminated. E reverses an explicit security-hardening choice with no gain over A/B/D. F conflicts with the self-containment requirement.
+
+Active candidates for validation: **A (utilityProcess)**, **C (in-process)**, **D (worker thread)**. Option B held in reserve pending research and spike outcomes.
 
 ## Scope
 
@@ -289,6 +301,8 @@ Variants:
 | Adds packaging complexity | Medium | High | Low | Low to medium | Medium | Low |
 | Keeps app self-contained | Likely | Likely | Yes | Yes | Likely | No |
 | Current evidence level | Docs only | Docs + concrete variants | Docs + local POC | Docs only | Docs only | Current broken behavior |
+
+**E** is eliminated (security-posture regression with no gain over A/B/D). **F** is eliminated (conflicts with self-containment requirement). Active candidates: **A, C, D**. **B** held in reserve.
 
 ## Decision Criteria
 


### PR DESCRIPTION
This updates the ACP packaged-app launch investigation with the R1-R4 research memo, narrows the viable options around the `spawn npx ENOENT` failure, and reframes the work so runtime resolution is the first gate. It also revises the spike sequencing to lead with the in-process host path and adds a dedicated plan for that spike. The tradeoff is that the docs now bias toward Option C first, keeping `utilityProcess` as a fallback only if runtime resolution works but main-process stability does not.