### PR TITLE
fix(acp): host claude-agent-acp in process for packaged launches

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -37,6 +37,10 @@ module.exports = {
 		// at package time, before code signing the application
 		new FusesPlugin({
 			version: FuseVersion.V1,
+			// Required for in-process ACP host: ELECTRON_RUN_AS_NODE=1 (injected via session-meta)
+			// makes the packaged Electron binary behave as a Node interpreter rather than launching
+			// a new app window. Trade-off: anyone who can set that env var and reach the binary can
+			// run arbitrary JS — evaluate before shipping beyond spike.
 			[FuseV1Options.RunAsNode]: true,
 			[FuseV1Options.EnableCookieEncryption]: true,
 			[FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,

--- a/forge.config.js
+++ b/forge.config.js
@@ -37,7 +37,7 @@ module.exports = {
 		// at package time, before code signing the application
 		new FusesPlugin({
 			version: FuseVersion.V1,
-			[FuseV1Options.RunAsNode]: false,
+			[FuseV1Options.RunAsNode]: true,
 			[FuseV1Options.EnableCookieEncryption]: true,
 			[FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
 			[FuseV1Options.EnableNodeCliInspectArguments]: false,

--- a/forge.config.js
+++ b/forge.config.js
@@ -37,10 +37,13 @@ module.exports = {
 		// at package time, before code signing the application
 		new FusesPlugin({
 			version: FuseVersion.V1,
-			// Required for in-process ACP host: ELECTRON_RUN_AS_NODE=1 (injected via session-meta)
-			// makes the packaged Electron binary behave as a Node interpreter rather than launching
-			// a new app window. Trade-off: anyone who can set that env var and reach the binary can
-			// run arbitrary JS — evaluate before shipping beyond spike.
+			// Electron's fuse docs make RunAsNode the switch that disables or enables
+			// ELECTRON_RUN_AS_NODE. Gremllm keeps it on because the pinned
+			// claude-agent-acp session setup hardcodes executable: process.execPath
+			// (local package node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1131-1133),
+			// and packaged launch only works when session-meta also injects
+			// ELECTRON_RUN_AS_NODE=1. Trade-off: enabling this fuse makes that env var
+			// meaningful again for the app binary. Source: https://packages.electronjs.org/fuses
 			[FuseV1Options.RunAsNode]: true,
 			[FuseV1Options.EnableCookieEncryption]: true,
 			[FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -128,15 +128,14 @@
         secrets-filepath (io/secrets-file-path user-data-dir)]
     (register-domain-handlers store secrets-filepath)
     (menu/create-menu store)
-    ;; Initialize ACP connection eagerly - subprocess starts at launch.
+    ;; Initialize ACP in-process agent eagerly at launch.
     ;; Session update callback receives raw JS params from SDK, coerces
     ;; via codec, and dispatches as a Nexus action.
     ;;
     ;; NOTE: Direct call, not a Nexus effect. Bootstrap infrastructure differs
     ;; from runtime capabilities - other ACP effects handle user operations.
     (acp-effects/initialize
-      {:on-session-update (acp-effects/make-session-update-callback store nil)
-       :is-packaged?      (.-isPackaged app)})))
+      {:on-session-update (acp-effects/make-session-update-callback store nil)})))
 
 (defn- initialize-app [store]
   (setup-system-resources store)

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -10,6 +10,10 @@
 ;; TODO: consider adopting https://github.com/stuartsierra/component
 (defonce ^:private state (atom nil))
 (defonce ^:private initialize-in-flight (atom nil))
+;; Tracks an in-flight shutdown dispose. Atoms (state, initialize-in-flight) are reset
+;; synchronously in shutdown; this atom lets initialize wait for the async dispose to
+;; settle before creating a new connection (init-during-shutdown race).
+(defonce ^:private shutdown-promise (atom nil))
 
 (defn slice-content-by-lines
   "Slice string content by 1-indexed line offset and limit.
@@ -73,8 +77,8 @@
                (reset! state {:connection conn :dispose-agent dispose-agent})
                nil))
       (.catch (fn [err]
-                (dispose-agent)
-                (throw err)))
+                (-> (dispose-agent)
+                    (.then (fn [_] (throw err))))))
       (.finally (fn []
                   (reset! initialize-in-flight nil)))))
 
@@ -108,13 +112,16 @@
      :on-session-update  callback receiving raw JS session update params from SDK.
      :on-permission      optional tap receiving coerced permission request params.
      :on-write           optional tap receiving coerced writeTextFile params."
-  [{:keys [on-session-update on-permission on-write]}]
+  [{:keys [on-session-update on-permission on-write] :as opts}]
   (cond
     @state
     (js/Promise.resolve nil)
 
     @initialize-in-flight
     (:promise @initialize-in-flight)
+
+    @shutdown-promise
+    (.then @shutdown-promise (fn [_] (initialize opts)))
 
     :else
     (let [^js result       (create-connection
@@ -170,14 +177,23 @@
         (js/console.error "ACP session update coercion failed" e params)))))
 
 (defn shutdown
-  "Tear down in-process ACP agent."
+  "Tear down in-process ACP agent. Returns a promise that resolves after all
+   disposes settle so callers (e.g. a before-quit hook) can await cleanup."
   []
   (let [initialized-dispose (:dispose-agent @state)
-        inflight-dispose    (:dispose-agent @initialize-in-flight)]
-    (when initialized-dispose
-      (initialized-dispose))
-    (when (and inflight-dispose
-               (not (identical? inflight-dispose initialized-dispose)))
-      (inflight-dispose))
+        inflight-dispose    (:dispose-agent @initialize-in-flight)
+        promises            (cond-> []
+                              initialized-dispose
+                              (conj (initialized-dispose))
+                              (and inflight-dispose
+                                   (not (identical? inflight-dispose initialized-dispose)))
+                              (conj (inflight-dispose)))]
     (reset! initialize-in-flight nil)
-    (reset! state nil)))
+    (reset! state nil)
+    (reset! shutdown-promise nil)
+    (if (seq promises)
+      (let [p (-> (js/Promise.all (clj->js promises))
+                  (.then (fn [_] (reset! shutdown-promise nil))))]
+        (reset! shutdown-promise p)
+        p)
+      (js/Promise.resolve nil))))

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -145,12 +145,17 @@
 
 (def ^:private session-meta
   "Adapter spreads params._meta.claudeCode.options into the child-spawn config.
-   ELECTRON_RUN_AS_NODE=1 is required so the Electron binary (process.execPath
-   in packaged mode) behaves as a Node interpreter instead of booting a new app
-   window. See acp-agent.js:1115 for the env merge."
+   - ELECTRON_RUN_AS_NODE=1 is required so the Electron binary (process.execPath
+     in packaged mode) behaves as a Node interpreter instead of booting a new app
+     window. See acp-agent.js:1115 for the env merge.
+   - settingSources: [] disables the Claude Code SDK's loading of user/project/local
+     settings files, reducing filesystem-watcher pressure. The adapter's own
+     SettingsManager is separate and already disposed on session teardown.
+     See acp-agent.js:1112-1114 for the override path."
   #js {:claudeCode
        #js {:options
-            #js {:env #js {:ELECTRON_RUN_AS_NODE "1"}}}})
+            #js {:env            #js {:ELECTRON_RUN_AS_NODE "1"}
+                 :settingSources #js []}}})
 
 (defn new-session
   "Create new ACP session for given working directory."

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -143,18 +143,26 @@
   (or (:connection @state)
       (throw (js/Error. "ACP not initialized"))))
 
-;; TODO: session-meta embeds adapter-internal knobs whose shape is keyed to acp-agent.js:1095.
-;; This effect file currently owns three concerns: connection lifecycle, ACP public API, and
-;; Claude-adapter overrides. The overrides want their own home before non-spike use.
+;; TODO: session-meta embeds adapter-internal knobs whose shape is keyed to the
+;; pinned claude-agent-acp session setup path (local package
+;; node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1095-1137).
+;; This effect file currently owns three concerns: connection lifecycle, ACP public API,
+;; and Claude-adapter overrides. The overrides want their own home before non-spike use.
 (def ^:private session-meta
-  "Adapter spreads params._meta.claudeCode.options into the child-spawn config.
-   - ELECTRON_RUN_AS_NODE=1 is required so the Electron binary (process.execPath
-     in packaged mode) behaves as a Node interpreter instead of booting a new app
-     window. See acp-agent.js:1115 for the env merge.
-   - settingSources: [] disables the Claude Code SDK's loading of user/project/local
-     settings files, reducing filesystem-watcher pressure. The adapter's own
-     SettingsManager is separate and already disposed on session teardown.
-     See acp-agent.js:1112-1114 for the override path."
+  "Adapter reads params._meta.claudeCode.options, merges env, and defaults
+   settingSources in the pinned session-setup path above. It then hardcodes
+   executable: process.execPath for the non-static-binary branch, so
+   _meta.claudeCode.options.executable is not a working override in this repo's
+   pinned adapter version.
+
+   Gremllm therefore injects:
+   - ELECTRON_RUN_AS_NODE=1 so the packaged Electron binary (process.execPath)
+     acts as a Node interpreter instead of relaunching the app window. This
+     depends on FuseV1Options.RunAsNode remaining enabled; see
+     https://packages.electronjs.org/fuses
+   - settingSources: [] to suppress Claude Code SDK user/project/local settings
+     loading for Gremllm sessions. The adapter's own SettingsManager lifecycle
+     remains separate."
   #js {:claudeCode
        #js {:options
             #js {:env            #js {:ELECTRON_RUN_AS_NODE "1"}

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -58,29 +58,6 @@
   [opts]
   (acp-factory/createConnection opts))
 
-(defn- log-runtime-probe!
-  "One-shot diagnostic at ACP init. Exposes what the claude-agent-acp adapter
-   will see when it spawns the Claude CLI: process.execPath (used as the
-   child-process interpreter), whether ELECTRON_RUN_AS_NODE is set (required
-   for the Electron binary to behave as Node), and resolver output for the
-   SDK's cli.js.
-   TODO(spike-in-process-acp-host): remove after runtime-resolution probe closes."
-  []
-  (let [probe #js {:execPath                js/process.execPath
-                   :electronRunAsNode       (-> js/process .-env .-ELECTRON_RUN_AS_NODE)
-                   :claudeCodeExecutable    (-> js/process .-env .-CLAUDE_CODE_EXECUTABLE)
-                   :nodeVersion             (-> js/process .-versions .-node)
-                   :electronVersion         (-> js/process .-versions .-electron)
-                   :resourcesPath           (.-resourcesPath js/process)
-                   :defaultApp              (.-defaultApp js/process)
-                   :execArgv                (.-execArgv js/process)}]
-    (js/console.log "[acp-runtime-probe] init" probe)
-    (try
-      (js/console.log "[acp-runtime-probe] claude-agent-sdk resolved at"
-                      (js/require.resolve "@anthropic-ai/claude-agent-sdk"))
-      (catch :default e
-        (js/console.log "[acp-runtime-probe] claude-agent-sdk resolve failed" (.-message e))))))
-
 (def ^:private client-info
   #js {:name "gremllm" :title "Gremllm" :version "0.1.0"})
 
@@ -147,8 +124,7 @@
     (.then @shutdown-promise (fn [_] (initialize opts)))
 
     :else
-    (let [_                (log-runtime-probe!)
-          ^js result       (create-connection
+    (let [^js result       (create-connection
                              #js {:onSessionUpdate     on-session-update
                                   :onReadTextFile      read-text-file
                                   :onRequestPermission (when on-permission
@@ -179,17 +155,8 @@
 (defn new-session
   "Create new ACP session for given working directory."
   [cwd]
-  (js/console.log "[acp-runtime-probe] newSession start" #js {:cwd cwd})
   (-> (.newSession (conn!) #js {:cwd cwd :mcpServers #js [] :_meta session-meta})
-      (.then (fn [result]
-               (js/console.log "[acp-runtime-probe] newSession ok"
-                               #js {:sessionId (.-sessionId result)})
-               (.-sessionId result)))
-      (.catch (fn [err]
-                (js/console.error "[acp-runtime-probe] newSession failed"
-                                  #js {:message (.-message err)
-                                       :stack   (.-stack err)})
-                (throw err)))))
+      (.then (fn [result] (.-sessionId result)))))
 
 (defn resume-session
   "Resume existing ACP session by ID."

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -204,10 +204,10 @@
                               (conj (inflight-dispose)))]
     (reset! initialize-in-flight nil)
     (reset! state nil)
-    (reset! shutdown-promise nil)
     (if (seq promises)
       (let [p (-> (js/Promise.all (clj->js promises))
                   (.then (fn [_] (reset! shutdown-promise nil))))]
         (reset! shutdown-promise p)
         p)
-      (js/Promise.resolve nil))))
+      (do (reset! shutdown-promise nil)
+          (js/Promise.resolve nil)))))

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -54,12 +54,6 @@
   [opts]
   (acp-factory/createConnection opts))
 
-(defn agent-package-mode
-  "ACP agent package mode policy: packaged apps prefer cached/default package
-   resolution, development prefers latest package resolution."
-  [is-packaged?]
-  (if is-packaged? "cached" "latest"))
-
 (def ^:private client-info
   #js {:name "gremllm" :title "Gremllm" :version "0.1.0"})
 
@@ -68,19 +62,18 @@
        :terminal false})
 
 (defn- start-connection!
-  "Perform ACP handshake, update state atoms, and kill subprocess on failure.
+  "Perform ACP handshake, update state atoms, and call dispose-agent on failure.
    Returns the initialization promise."
-  [^js conn ^js subprocess ^js protocol-version]
+  [^js conn ^js protocol-version dispose-agent]
   (-> (.initialize conn
         #js {:protocolVersion    protocol-version
              :clientCapabilities client-capabilities
              :clientInfo         client-info})
       (.then (fn [_]
-               (reset! state {:connection conn :subprocess subprocess})
+               (reset! state {:connection conn :dispose-agent dispose-agent})
                nil))
       (.catch (fn [err]
-                (when subprocess
-                  (.kill subprocess "SIGTERM"))
+                (dispose-agent)
                 (throw err)))
       (.finally (fn []
                   (reset! initialize-in-flight nil)))))
@@ -113,10 +106,9 @@
   "Initialize ACP connection eagerly. Idempotent.
    opts keys:
      :on-session-update  callback receiving raw JS session update params from SDK.
-     :is-packaged?       Electron app packaging state; selects ACP agent package mode policy.
      :on-permission      optional tap receiving coerced permission request params.
      :on-write           optional tap receiving coerced writeTextFile params."
-  [{:keys [on-session-update is-packaged? on-permission on-write]}]
+  [{:keys [on-session-update on-permission on-write]}]
   (cond
     @state
     (js/Promise.resolve nil)
@@ -125,20 +117,19 @@
     (:promise @initialize-in-flight)
 
     :else
-    (let [^js result (create-connection
-                       #js {:onSessionUpdate     on-session-update
-                            :onReadTextFile      read-text-file
-                            :agentPackageMode    (agent-package-mode (boolean is-packaged?))
-                            :onRequestPermission (when on-permission
-                                                   (make-permission-callback on-permission))
-                            :onWriteTextFile     (when on-write
-                                                   (make-write-callback on-write))})
-          init-promise
-          (start-connection! (.-connection result)
-                             (.-subprocess result)
-                             (.-protocolVersion result))]
-      (reset! initialize-in-flight {:promise init-promise
-                                    :subprocess (.-subprocess result)})
+    (let [^js result       (create-connection
+                             #js {:onSessionUpdate     on-session-update
+                                  :onReadTextFile      read-text-file
+                                  :onRequestPermission (when on-permission
+                                                         (make-permission-callback on-permission))
+                                  :onWriteTextFile     (when on-write
+                                                         (make-write-callback on-write))})
+          dispose-agent    (.-disposeAgent result)
+          init-promise     (start-connection! (.-connection result)
+                                              (.-protocolVersion result)
+                                              dispose-agent)]
+      (reset! initialize-in-flight {:promise       init-promise
+                                    :dispose-agent dispose-agent})
       init-promise)))
 
 (defn- ^js conn! []
@@ -179,14 +170,14 @@
         (js/console.error "ACP session update coercion failed" e params)))))
 
 (defn shutdown
-  "Terminate ACP subprocess."
+  "Tear down in-process ACP agent."
   []
-  (let [^js initialized-subprocess (:subprocess @state)
-        ^js inflight-subprocess    (:subprocess @initialize-in-flight)]
-    (when initialized-subprocess
-      (.kill initialized-subprocess "SIGTERM"))
-    (when (and inflight-subprocess
-               (not (identical? inflight-subprocess initialized-subprocess)))
-      (.kill inflight-subprocess "SIGTERM"))
+  (let [initialized-dispose (:dispose-agent @state)
+        inflight-dispose    (:dispose-agent @initialize-in-flight)]
+    (when initialized-dispose
+      (initialized-dispose))
+    (when (and inflight-dispose
+               (not (identical? inflight-dispose initialized-dispose)))
+      (inflight-dispose))
     (reset! initialize-in-flight nil)
     (reset! state nil)))

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -143,6 +143,9 @@
   (or (:connection @state)
       (throw (js/Error. "ACP not initialized"))))
 
+;; TODO: session-meta embeds adapter-internal knobs whose shape is keyed to acp-agent.js:1095.
+;; This effect file currently owns three concerns: connection lifecycle, ACP public API, and
+;; Claude-adapter overrides. The overrides want their own home before non-spike use.
 (def ^:private session-meta
   "Adapter spreads params._meta.claudeCode.options into the child-spawn config.
    - ELECTRON_RUN_AS_NODE=1 is required so the Electron binary (process.execPath

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -58,6 +58,29 @@
   [opts]
   (acp-factory/createConnection opts))
 
+(defn- log-runtime-probe!
+  "One-shot diagnostic at ACP init. Exposes what the claude-agent-acp adapter
+   will see when it spawns the Claude CLI: process.execPath (used as the
+   child-process interpreter), whether ELECTRON_RUN_AS_NODE is set (required
+   for the Electron binary to behave as Node), and resolver output for the
+   SDK's cli.js.
+   TODO(spike-in-process-acp-host): remove after runtime-resolution probe closes."
+  []
+  (let [probe #js {:execPath                js/process.execPath
+                   :electronRunAsNode       (-> js/process .-env .-ELECTRON_RUN_AS_NODE)
+                   :claudeCodeExecutable    (-> js/process .-env .-CLAUDE_CODE_EXECUTABLE)
+                   :nodeVersion             (-> js/process .-versions .-node)
+                   :electronVersion         (-> js/process .-versions .-electron)
+                   :resourcesPath           (.-resourcesPath js/process)
+                   :defaultApp              (.-defaultApp js/process)
+                   :execArgv                (.-execArgv js/process)}]
+    (js/console.log "[acp-runtime-probe] init" probe)
+    (try
+      (js/console.log "[acp-runtime-probe] claude-agent-sdk resolved at"
+                      (js/require.resolve "@anthropic-ai/claude-agent-sdk"))
+      (catch :default e
+        (js/console.log "[acp-runtime-probe] claude-agent-sdk resolve failed" (.-message e))))))
+
 (def ^:private client-info
   #js {:name "gremllm" :title "Gremllm" :version "0.1.0"})
 
@@ -124,7 +147,8 @@
     (.then @shutdown-promise (fn [_] (initialize opts)))
 
     :else
-    (let [^js result       (create-connection
+    (let [_                (log-runtime-probe!)
+          ^js result       (create-connection
                              #js {:onSessionUpdate     on-session-update
                                   :onReadTextFile      read-text-file
                                   :onRequestPermission (when on-permission
@@ -143,17 +167,35 @@
   (or (:connection @state)
       (throw (js/Error. "ACP not initialized"))))
 
+(def ^:private session-meta
+  "Adapter spreads params._meta.claudeCode.options into the child-spawn config.
+   ELECTRON_RUN_AS_NODE=1 is required so the Electron binary (process.execPath
+   in packaged mode) behaves as a Node interpreter instead of booting a new app
+   window. See acp-agent.js:1115 for the env merge."
+  #js {:claudeCode
+       #js {:options
+            #js {:env #js {:ELECTRON_RUN_AS_NODE "1"}}}})
+
 (defn new-session
   "Create new ACP session for given working directory."
   [cwd]
-  (-> (.newSession (conn!) #js {:cwd cwd :mcpServers #js []})
-      (.then (fn [result] (.-sessionId result)))))
+  (js/console.log "[acp-runtime-probe] newSession start" #js {:cwd cwd})
+  (-> (.newSession (conn!) #js {:cwd cwd :mcpServers #js [] :_meta session-meta})
+      (.then (fn [result]
+               (js/console.log "[acp-runtime-probe] newSession ok"
+                               #js {:sessionId (.-sessionId result)})
+               (.-sessionId result)))
+      (.catch (fn [err]
+                (js/console.error "[acp-runtime-probe] newSession failed"
+                                  #js {:message (.-message err)
+                                       :stack   (.-stack err)})
+                (throw err)))))
 
 (defn resume-session
   "Resume existing ACP session by ID."
   [cwd acp-session-id]
   (-> (.unstable_resumeSession (conn!)
-        #js {:sessionId acp-session-id :cwd cwd :mcpServers #js []})
+        #js {:sessionId acp-session-id :cwd cwd :mcpServers #js [] :_meta session-meta})
       (.then (fn [_] acp-session-id))))
 
 (defn prompt

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -2,6 +2,7 @@
   "ACP effect handlers - owns connection lifecycle.
    JS module is a thin factory; CLJS manages state and public API."
   (:require [clojure.string :as str]
+            [gremllm.main.effects.acp.claude-adapter :as claude-adapter]
             [gremllm.schema.codec :as codec]
             [nexus.registry :as nxr]
             ["/js/acp/index" :as acp-factory]
@@ -10,10 +11,6 @@
 ;; TODO: consider adopting https://github.com/stuartsierra/component
 (defonce ^:private state (atom nil))
 (defonce ^:private initialize-in-flight (atom nil))
-;; Tracks an in-flight shutdown dispose. Atoms (state, initialize-in-flight) are reset
-;; synchronously in shutdown; this atom lets initialize wait for the async dispose to
-;; settle before creating a new connection (init-during-shutdown race).
-(defonce ^:private shutdown-promise (atom nil))
 
 (defn slice-content-by-lines
   "Slice string content by 1-indexed line offset and limit.
@@ -120,9 +117,6 @@
     @initialize-in-flight
     (:promise @initialize-in-flight)
 
-    @shutdown-promise
-    (.then @shutdown-promise (fn [_] (initialize opts)))
-
     :else
     (let [^js result       (create-connection
                              #js {:onSessionUpdate     on-session-update
@@ -143,42 +137,17 @@
   (or (:connection @state)
       (throw (js/Error. "ACP not initialized"))))
 
-;; TODO: session-meta embeds adapter-internal knobs whose shape is keyed to the
-;; pinned claude-agent-acp session setup path (local package
-;; node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1095-1137).
-;; This effect file currently owns three concerns: connection lifecycle, ACP public API,
-;; and Claude-adapter overrides. The overrides want their own home before non-spike use.
-(def ^:private session-meta
-  "Adapter reads params._meta.claudeCode.options, merges env, and defaults
-   settingSources in the pinned session-setup path above. It then hardcodes
-   executable: process.execPath for the non-static-binary branch, so
-   _meta.claudeCode.options.executable is not a working override in this repo's
-   pinned adapter version.
-
-   Gremllm therefore injects:
-   - ELECTRON_RUN_AS_NODE=1 so the packaged Electron binary (process.execPath)
-     acts as a Node interpreter instead of relaunching the app window. This
-     depends on FuseV1Options.RunAsNode remaining enabled; see
-     https://packages.electronjs.org/fuses
-   - settingSources: [] to suppress Claude Code SDK user/project/local settings
-     loading for Gremllm sessions. The adapter's own SettingsManager lifecycle
-     remains separate."
-  #js {:claudeCode
-       #js {:options
-            #js {:env            #js {:ELECTRON_RUN_AS_NODE "1"}
-                 :settingSources #js []}}})
-
 (defn new-session
   "Create new ACP session for given working directory."
   [cwd]
-  (-> (.newSession (conn!) #js {:cwd cwd :mcpServers #js [] :_meta session-meta})
+  (-> (.newSession (conn!) #js {:cwd cwd :mcpServers #js [] :_meta claude-adapter/session-meta})
       (.then (fn [result] (.-sessionId result)))))
 
 (defn resume-session
   "Resume existing ACP session by ID."
   [cwd acp-session-id]
   (-> (.unstable_resumeSession (conn!)
-        #js {:sessionId acp-session-id :cwd cwd :mcpServers #js [] :_meta session-meta})
+        #js {:sessionId acp-session-id :cwd cwd :mcpServers #js [] :_meta claude-adapter/session-meta})
       (.then (fn [_] acp-session-id))))
 
 (defn prompt
@@ -216,9 +185,5 @@
     (reset! initialize-in-flight nil)
     (reset! state nil)
     (if (seq promises)
-      (let [p (-> (js/Promise.all (clj->js promises))
-                  (.then (fn [_] (reset! shutdown-promise nil))))]
-        (reset! shutdown-promise p)
-        p)
-      (do (reset! shutdown-promise nil)
-          (js/Promise.resolve nil)))))
+      (js/Promise.all (into-array promises))
+      (js/Promise.resolve nil))))

--- a/src/gremllm/main/effects/acp/claude_adapter.cljs
+++ b/src/gremllm/main/effects/acp/claude_adapter.cljs
@@ -1,0 +1,22 @@
+(ns gremllm.main.effects.acp.claude-adapter
+  "Claude-adapter overrides for ACP session setup.
+
+   These knobs are keyed to the pinned claude-agent-acp session setup path
+   (local package node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1095-1137).
+   Adapter reads params._meta.claudeCode.options, merges env, and defaults settingSources
+   in that path. It then hardcodes executable: process.execPath for the non-static-binary
+   branch, so _meta.claudeCode.options.executable is not a working override in this repo's
+   pinned adapter version.
+
+   Gremllm therefore injects:
+   - ELECTRON_RUN_AS_NODE=1 so the packaged Electron binary (process.execPath) acts as a
+     Node interpreter instead of relaunching the app window. This depends on
+     FuseV1Options.RunAsNode remaining enabled; see https://packages.electronjs.org/fuses
+   - settingSources: [] to suppress Claude Code SDK user/project/local settings loading for
+     Gremllm sessions. The adapter's own SettingsManager lifecycle remains separate.")
+
+(def session-meta
+  #js {:claudeCode
+       #js {:options
+            #js {:env            #js {:ELECTRON_RUN_AS_NODE "1"}
+                 :settingSources #js []}}})

--- a/src/js/acp/index.js
+++ b/src/js/acp/index.js
@@ -3,8 +3,6 @@ const { ClaudeAcpAgent } = require("@agentclientprotocol/claude-agent-acp/dist/l
 const { makeResolver, requestedToolName } = require("./permission");
 const permission = require("./permission");
 
-const sessionCwdMap = new Map();
-
 function rememberToolName(toolNamesByCallId, params) {
   const update = params?.update;
   const toolCallId = update?.toolCallId;
@@ -47,12 +45,17 @@ function createConnection(options = {}) {
   const clientStream = acp.ndJsonStream(clientToAgent.writable, agentToClient.readable);
   const agentStream = acp.ndJsonStream(agentToClient.writable, clientToAgent.readable);
 
+  const sessionCwdMap = new Map();
+
   // Agent is captured synchronously — AgentSideConnection calls the factory immediately
   let agent;
   new acp.AgentSideConnection((client) => {
     agent = new ClaudeAcpAgent(client);
     return agent;
   }, agentStream);
+  if (!agent) {
+    throw new Error("AgentSideConnection did not invoke factory synchronously");
+  }
 
   const resolver = makeResolver((sessionId) => sessionCwdMap.get(sessionId));
 

--- a/src/js/acp/index.js
+++ b/src/js/acp/index.js
@@ -38,7 +38,10 @@ function createConnection(options = {}) {
   const callbacks = options;
   const toolNamesByCallId = new Map();
 
-  // Paired transform streams for in-process bidirectional message passing
+  // Paired transform streams for in-process bidirectional message passing.
+  // TODO: failure propagation is unexamined — if the agent side throws mid-message or the
+  // ndjson codec encounters a malformed frame, it's unclear whether the error surfaces to
+  // the connection's promise chain or is silently dropped.
   const clientToAgent = new TransformStream();
   const agentToClient = new TransformStream();
 
@@ -47,7 +50,9 @@ function createConnection(options = {}) {
 
   const sessionCwdMap = new Map();
 
-  // Agent is captured synchronously — AgentSideConnection calls the factory immediately
+  // Agent is captured synchronously — AgentSideConnection calls the factory immediately.
+  // Load-bearing: disposeAgent below depends on `agent` being set at construction time.
+  // TODO: verify this is a guaranteed SDK contract, not an observed implementation detail.
   let agent;
   new acp.AgentSideConnection((client) => {
     agent = new ClaudeAcpAgent(client);

--- a/src/js/acp/index.js
+++ b/src/js/acp/index.js
@@ -38,7 +38,11 @@ function createConnection(options = {}) {
   const callbacks = options;
   const toolNamesByCallId = new Map();
 
-  // Paired transform streams for in-process bidirectional message passing.
+  // The ACP SDK accepts generic streams for ndjson transport (see the pinned
+  // local packages node_modules/@agentclientprotocol/sdk/dist/acp.js and
+  // node_modules/@agentclientprotocol/sdk/dist/stream.js), so Gremllm hosts
+  // claude-agent-acp in-process and bridges client/agent traffic with paired
+  // TransformStreams instead of subprocess stdio.
   // TODO: failure propagation is unexamined — if the agent side throws mid-message or the
   // ndjson codec encounters a malformed frame, it's unclear whether the error surfaces to
   // the connection's promise chain or is silently dropped.

--- a/src/js/acp/index.js
+++ b/src/js/acp/index.js
@@ -1,31 +1,9 @@
-const { spawn } = require("node:child_process");
-const { Writable, Readable } = require("node:stream");
 const acp = require("@agentclientprotocol/sdk");
-const claudeAgentPackage = require("@agentclientprotocol/claude-agent-acp/package.json");
+const { ClaudeAcpAgent } = require("@agentclientprotocol/claude-agent-acp/dist/lib.js");
 const { makeResolver, requestedToolName } = require("./permission");
 const permission = require("./permission");
 
 const sessionCwdMap = new Map();
-
-function getClaudeAgentPackageInfo() {
-  const packageName = claudeAgentPackage.name;
-  const version = claudeAgentPackage.version;
-  const bin = "claude-agent-acp";
-
-  return {
-    packageName,
-    version,
-    packageSpec: `${packageName}@${version}`,
-    bin
-  };
-}
-
-const {
-  packageName: CLAUDE_AGENT_PACKAGE,
-  version: CLAUDE_AGENT_VERSION,
-  packageSpec: CLAUDE_AGENT_PACKAGE_SPEC,
-  bin: CLAUDE_AGENT_BIN
-} = getClaudeAgentPackageInfo();
 
 function rememberToolName(toolNamesByCallId, params) {
   const update = params?.update;
@@ -58,50 +36,23 @@ function enrichPermissionParams(toolNamesByCallId, params) {
   };
 }
 
-function logConfiguredAgentVersion() {
-  console.log("[ACP] claude-agent-acp@" + CLAUDE_AGENT_VERSION);
-}
-
-function normalizeAgentPackageMode(agentPackageMode) {
-  return agentPackageMode === "latest" ? "latest" : "cached";
-}
-
-function buildNpxAgentPackageConfig(agentPackageMode) {
-  if (normalizeAgentPackageMode(agentPackageMode) === "cached") {
-    return {
-      command: "npx",
-      args: [CLAUDE_AGENT_BIN],
-      envPatch: {}
-    };
-  }
-
-  return {
-    command: "npx",
-    args: [
-      "--yes",
-      `--package=${CLAUDE_AGENT_PACKAGE_SPEC}`,
-      "--",
-      CLAUDE_AGENT_BIN
-    ],
-    envPatch: {
-      npm_config_prefer_online: "true"
-    }
-  };
-}
-
 function createConnection(options = {}) {
   const callbacks = options;
-  const { command, args, envPatch } = buildNpxAgentPackageConfig(options.agentPackageMode);
   const toolNamesByCallId = new Map();
 
-  const subprocess = spawn(command, args, {
-    stdio: ["pipe", "pipe", "inherit"],
-    env: { ...process.env, ...envPatch }
-  });
+  // Paired transform streams for in-process bidirectional message passing
+  const clientToAgent = new TransformStream();
+  const agentToClient = new TransformStream();
 
-  if (normalizeAgentPackageMode(options.agentPackageMode) === "latest") {
-    logConfiguredAgentVersion();
-  }
+  const clientStream = acp.ndJsonStream(clientToAgent.writable, agentToClient.readable);
+  const agentStream = acp.ndJsonStream(agentToClient.writable, clientToAgent.readable);
+
+  // Agent is captured synchronously — AgentSideConnection calls the factory immediately
+  let agent;
+  new acp.AgentSideConnection((client) => {
+    agent = new ClaudeAcpAgent(client);
+    return agent;
+  }, agentStream);
 
   const resolver = makeResolver((sessionId) => sessionCwdMap.get(sessionId));
 
@@ -135,10 +86,7 @@ function createConnection(options = {}) {
     }
   };
 
-  const input = Writable.toWeb(subprocess.stdin);
-  const output = Readable.toWeb(subprocess.stdout);
-  const stream = acp.ndJsonStream(input, output);
-  const connection = new acp.ClientSideConnection(() => client, stream);
+  const connection = new acp.ClientSideConnection(() => client, clientStream);
 
   const originalNewSession = connection.newSession.bind(connection);
   connection.newSession = async (params) => {
@@ -154,9 +102,17 @@ function createConnection(options = {}) {
     return result;
   };
 
+  async function disposeAgent() {
+    if (agent) {
+      await agent.dispose().catch(() => {});
+    }
+    clientToAgent.writable.close().catch(() => {});
+    agentToClient.writable.close().catch(() => {});
+  }
+
   return {
     connection,
-    subprocess,
+    disposeAgent,
     protocolVersion: acp.PROTOCOL_VERSION
   };
 }
@@ -164,14 +120,10 @@ function createConnection(options = {}) {
 module.exports = {
   createConnection,
   __test__: {
-    buildNpxAgentPackageConfig,
-    getClaudeAgentPackageInfo,
     enrichPermissionParams,
     rememberToolName,
     makeResolver,
     permissionRequestedToolName: requestedToolName,
-    permissionRequestedPath: permission.__test__.requestedPath,
-    claudeAgentPackageSpec: CLAUDE_AGENT_PACKAGE_SPEC,
-    claudeAgentVersion: CLAUDE_AGENT_VERSION
+    permissionRequestedPath: permission.__test__.requestedPath
   }
 };

--- a/src/js/acp/index.js
+++ b/src/js/acp/index.js
@@ -54,17 +54,13 @@ function createConnection(options = {}) {
 
   const sessionCwdMap = new Map();
 
-  // Agent is captured synchronously — AgentSideConnection calls the factory immediately.
-  // Load-bearing: disposeAgent below depends on `agent` being set at construction time.
-  // TODO: verify this is a guaranteed SDK contract, not an observed implementation detail.
-  let agent;
-  new acp.AgentSideConnection((client) => {
-    agent = new ClaudeAcpAgent(client);
-    return agent;
-  }, agentStream);
-  if (!agent) {
-    throw new Error("AgentSideConnection did not invoke factory synchronously");
-  }
+  const agentReady = new Promise((resolve) => {
+    new acp.AgentSideConnection((client) => {
+      const agent = new ClaudeAcpAgent(client);
+      resolve(agent);
+      return agent;
+    }, agentStream);
+  });
 
   const resolver = makeResolver((sessionId) => sessionCwdMap.get(sessionId));
 
@@ -115,9 +111,8 @@ function createConnection(options = {}) {
   };
 
   async function disposeAgent() {
-    if (agent) {
-      await agent.dispose().catch(() => {});
-    }
+    const agent = await agentReady;
+    await agent.dispose().catch((err) => console.error("[ACP] agent dispose failed", err));
     clientToAgent.writable.close().catch(() => {});
     agentToClient.writable.close().catch(() => {});
   }

--- a/src/js/acp/permission.js
+++ b/src/js/acp/permission.js
@@ -61,9 +61,10 @@ function makeResolver(getSessionCwd) {
       const normalizedRequested = normalizePath(requestedPath(toolCall));
       if (normalizedCwd && normalizedRequested && isWithinRoot(normalizedRequested, normalizedCwd)) {
         // Critical workflow nuance: for Gremllm, approving an in-workspace
-        // edit/write means "allow the agent to produce a diff proposal", not
+        // edit/write means "allow the agent to complete the proposal path", not
         // "write the file immediately". The ACP bridge keeps writeTextFile as a
-        // dry-run no-op, so the successful path here is still non-mutating.
+        // dry-run no-op, so the successful path here is still non-mutating and
+        // disk changes remain gated behind Gremllm's later accept/reject flow.
         // Rejecting permission changes the semantics entirely: Claude reports
         // that the user refused the tool, and the proposal step fails instead
         // of returning a reviewable diff.

--- a/test/gremllm/main/effects/acp_integration_test.cljs
+++ b/test/gremllm/main/effects/acp_integration_test.cljs
@@ -44,8 +44,7 @@
       (let [store    (atom {})
             captured (atom [])
             cwd      (.cwd js/process)]
-        (-> (acp/initialize {:on-session-update (acp/make-session-update-callback store #(swap! captured conj %))
-                              :is-packaged?      false})
+        (-> (acp/initialize {:on-session-update (acp/make-session-update-callback store #(swap! captured conj %))})
             (.then (fn [_] (acp/new-session cwd)))
             (.then (fn [session-id]
                      (is (string? session-id))
@@ -89,7 +88,6 @@
                      (with-redefs [acp/read-text-file (make-read-recorder (:on-read recorder))]
                        (acp/initialize
                          {:on-session-update (acp/make-session-update-callback store (:on-session-update recorder))
-                          :is-packaged?      false
                           :on-permission     (:on-permission recorder)
                           :on-write          (:on-write recorder)}))))
             (.then (fn [_] (acp/new-session @tmp-dir)))
@@ -144,7 +142,6 @@
                      (with-redefs [acp/read-text-file (make-read-recorder (:on-read recorder))]
                        (acp/initialize
                          {:on-session-update (acp/make-session-update-callback store (:on-session-update recorder))
-                          :is-packaged?      false
                           :on-permission     (:on-permission recorder)
                           :on-write          (:on-write recorder)}))))
             (.then (fn [_] (acp/new-session @tmp-dir)))
@@ -273,7 +270,6 @@
                      (with-redefs [acp/read-text-file (make-read-recorder (:on-read recorder))]
                        (acp/initialize
                          {:on-session-update (acp/make-session-update-callback store (:on-session-update recorder))
-                          :is-packaged?      false
                           :on-permission     (:on-permission recorder)
                           :on-write          (:on-write recorder)}))))
             (.then (fn [_] (acp/new-session @tmp-dir)))

--- a/test/gremllm/main/effects/acp_test.cljs
+++ b/test/gremllm/main/effects/acp_test.cljs
@@ -353,35 +353,3 @@
                              (.finally (fn [] (done)))))))
               (.catch (fn [e] (js/console.error "unexpected error" e) (done)))))))))
 
-(deftest test-initialize-waits-for-shutdown-dispose
-  (testing "initialize called during async shutdown defers until dispose settles"
-    (async done
-      (let [resolve-dispose (atom nil)
-            deferred        (js/Promise. (fn [r _] (reset! resolve-dispose r)))
-            dispose-settled (atom false)
-            conn            #js {:initialize
-                                 (fn [_] (js/Promise.resolve #js {:agentCapabilities #js {}}))}
-            dispose-agent   (fn []
-                              (.then deferred (fn [_] (reset! dispose-settled true))))
-            result          #js {:connection   conn
-                                 :disposeAgent dispose-agent
-                                 :protocolVersion "v"}
-            create-count    (atom 0)]
-        (with-redefs [acp/create-connection (fn [_] (swap! create-count inc) result)]
-          (-> (initialize-dev (fn [_] nil))
-              (.then (fn [_]
-                       (acp/shutdown)
-                       ;; Immediately call initialize while dispose is still pending
-                       (let [init-p (initialize-dev (fn [_] nil))]
-                         ;; KEY: no new connection created synchronously
-                         (is (= 1 @create-count)
-                             "new connection should not be created until dispose settles")
-                         (@resolve-dispose nil)
-                         ;; Wait for init-p to settle (resolve or reject — real create-connection
-                         ;; is used here since with-redefs has unwound for the async retry)
-                         (-> (.allSettled js/Promise #js [init-p])
-                             (.then (fn [_]
-                                      (is (= true @dispose-settled)
-                                          "dispose must settle before init-p can settle")))
-                             (.finally (fn [] (.then (acp/shutdown) (fn [_] (done)))))))))
-              (.catch (fn [e] (js/console.error "unexpected error" e) (done)))))))))

--- a/test/gremllm/main/effects/acp_test.cljs
+++ b/test/gremllm/main/effects/acp_test.cljs
@@ -16,7 +16,7 @@
                       :new-session []
                       :resume-session []
                       :prompt []
-                      :kill []})
+                      :dispose-count 0})
          conn  #js {:initialize
                     (fn [payload]
                       (swap! calls update :initialize conj payload)
@@ -33,10 +33,11 @@
                     (fn [payload]
                       (swap! calls update :prompt conj payload)
                       (js/Promise.resolve #js {:stopReason "end_turn"}))}
-         subprocess #js {:kill (fn [signal]
-                                 (swap! calls update :kill conj signal))}
+         dispose-agent (fn []
+                         (swap! calls update :dispose-count inc)
+                         (js/Promise.resolve nil))
          result #js {:connection conn
-                     :subprocess subprocess
+                     :disposeAgent dispose-agent
                      :protocolVersion "test-protocol"}]
      {:calls calls
       :result result})))
@@ -52,9 +53,9 @@
                        (:result (nth envs (dec i)))))}))
 
 (defn- initialize-dev
-  "Initialize ACP in test default mode (non-packaged)."
+  "Initialize ACP in test default mode."
   [on-update]
-  (acp/initialize {:on-session-update on-update :is-packaged? false}))
+  (acp/initialize {:on-session-update on-update}))
 
 (deftest test-initialize-wiring
   (testing "passes client info and callback to connection"
@@ -106,43 +107,6 @@
                           (acp/shutdown)
                           (done)))))))))
 
-(defn- spawn-config->map [^js config]
-  {:command   (.-command config)
-   :args      (vec (js->clj (.-args config)))
-   :env-patch (js->clj (.-envPatch config))})
-
-(deftest test-build-npx-agent-package-config
-  (let [build        (.. acp-module -__test__ -buildNpxAgentPackageConfig)
-        package-spec (.. acp-module -__test__ -claudeAgentPackageSpec)]
-    (testing "latest mode forces online package resolution"
-      (is (= {:command   "npx"
-              :args      ["--yes"
-                          (str "--package=" package-spec)
-                          "--"
-                          "claude-agent-acp"]
-              :env-patch {"npm_config_prefer_online" "true"}}
-             (spawn-config->map (build "latest")))))
-    (testing "cached mode uses the installed package binary"
-      (is (= {:command   "npx"
-              :args      ["claude-agent-acp"]
-              :env-patch {}}
-             (spawn-config->map (build "cached")))))
-    (testing "invalid mode falls back to cached"
-      (is (= (spawn-config->map (build "cached"))
-             (spawn-config->map (build "not-a-valid-mode")))))))
-
-(deftest test-claude-agent-package-info
-  (let [get-package-info (.. acp-module -__test__ -getClaudeAgentPackageInfo)
-        ^js package-json (js/require "@agentclientprotocol/claude-agent-acp/package.json")]
-    (is (fn? get-package-info))
-    (when (fn? get-package-info)
-      (let [info (js->clj (get-package-info) :keywordize-keys true)]
-        (is (= {:packageName (.-name package-json)
-                :version     (.-version package-json)
-                :packageSpec (str (.-name package-json) "@" (.-version package-json))
-                :bin         "claude-agent-acp"}
-               info))))))
-
 (deftest test-session-and-prompt-delegation
   (testing "delegates new-session, resume-session, and prompt to connection"
     (async done
@@ -176,7 +140,7 @@
                           (done)))))))))
 
 (deftest test-lifecycle-guardrails
-  (testing "double initialize is idempotent, shutdown kills subprocess, post-shutdown throws"
+  (testing "double initialize is idempotent, shutdown disposes agent, post-shutdown throws"
     (async done
       (let [{:keys [calls result]} (make-fake-env)
             create-count (atom 0)]
@@ -189,7 +153,7 @@
               (.then (fn [_]
                        (is (= 1 @create-count))
                        (acp/shutdown)
-                       (is (= ["SIGTERM"] (:kill @calls)))
+                       (is (= 1 (:dispose-count @calls)))
                        (is (thrown-with-msg? js/Error #"ACP not initialized"
                              (acp/new-session "/tmp/ws")))))
               (.finally (fn []
@@ -210,7 +174,7 @@
                        (is false "Expected first initialize call to fail")))
               (.catch (fn [err]
                         (is (= "init failed" (.-message err)))
-                        (is (= ["SIGTERM"] (:kill @(:calls failing-env))))
+                        (is (= 1 (:dispose-count @(:calls failing-env))))
                         (is (thrown-with-msg? js/Error #"ACP not initialized"
                               (acp/new-session "/tmp/ws")))
                         ;; Re-bind for retry because async Promise callbacks run

--- a/test/gremllm/main/effects/acp_test.cljs
+++ b/test/gremllm/main/effects/acp_test.cljs
@@ -76,8 +76,7 @@
                          (is (= "0.1.0" (.. payload -clientInfo -version)))
                          (is (= false (.. payload -clientCapabilities -terminal))))))
               (.finally (fn []
-                          (acp/shutdown)
-                          (done)))))))))
+                          (.then (acp/shutdown) (fn [_] (done)))))))))))
 
 (deftest test-callback-fires-and-coerces-diffs
   (testing "onSessionUpdate callback receives raw JS, coerces to CLJS, tool-response-has-diffs? true"
@@ -104,8 +103,7 @@
                            (is (= "s-test" (:acp-session-id coerced)))
                            (is (codec/tool-response-has-diffs? (:update coerced)))))))
               (.finally (fn []
-                          (acp/shutdown)
-                          (done)))))))))
+                          (.then (acp/shutdown) (fn [_] (done)))))))))))
 
 (deftest test-session-and-prompt-delegation
   (testing "delegates new-session, resume-session, and prompt to connection"
@@ -136,8 +134,7 @@
                            (is (= "text" (.-type first-block)))
                            (is (= "Say only: Hello" (.-text first-block)))))))
               (.finally (fn []
-                          (acp/shutdown)
-                          (done)))))))))
+                          (.then (acp/shutdown) (fn [_] (done)))))))))))
 
 (deftest test-lifecycle-guardrails
   (testing "double initialize is idempotent, shutdown disposes agent, post-shutdown throws"
@@ -157,8 +154,7 @@
                        (is (thrown-with-msg? js/Error #"ACP not initialized"
                              (acp/new-session "/tmp/ws")))))
               (.finally (fn []
-                          (acp/shutdown)
-                          (done)))))))))
+                          (.then (acp/shutdown) (fn [_] (done)))))))))))
 
 (deftest test-initialize-failure-does-not-poison-state
   (testing "failed initialize cleans up and allows retry"
@@ -186,8 +182,7 @@
                        (is (= "s-456" session-id))
                        (is (= 2 @create-count))))
               (.finally (fn []
-                          (acp/shutdown)
-                          (done)))))))))
+                          (.then (acp/shutdown) (fn [_] (done)))))))))))
 
 (deftest test-remember-and-enrich-tool-name
   (let [remember-tool-name     (.. acp-module -__test__ -rememberToolName)
@@ -200,9 +195,9 @@
     (let [^js enriched (enrich-permission-params
                          tool-names
                          #js {:sessionId "session-1"
-                              :toolCall  #js {:toolCallId "toolu_01"
+                              :toolCall  #js {:toolCallId "toolu_01"}
                                              :title      "Edit `/tmp/test.md`"
-                                             :rawInput   #js {:file_path "/tmp/test.md"}}
+                                             :rawInput   #js {:file_path "/tmp/test.md"}
                               :options   #js []})]
       (is (= "mcp__acp__Edit" (.. enriched -toolCall -toolName))))))
 
@@ -305,3 +300,88 @@
                                        (.rm fs dir #js {:recursive true
                                                         :force true})))))))
             (.finally (fn [] (done))))))))
+
+;; --- Step 4a: async dispose-promise chaining ---
+
+(deftest test-start-connection-catch-chains-rethrow-after-dispose
+  (testing "initialization failure: error only propagates after dispose promise settles"
+    (async done
+      (let [events          (atom [])
+            resolve-dispose (atom nil)
+            deferred        (js/Promise. (fn [r _] (reset! resolve-dispose r)))
+            dispose-agent   (fn []
+                              (swap! events conj :dispose-called)
+                              (.then deferred (fn [_] (swap! events conj :dispose-settled))))
+            conn            #js {:initialize (fn [_] (js/Promise.reject (js/Error. "boom")))}
+            result          #js {:connection   conn
+                                 :disposeAgent dispose-agent
+                                 :protocolVersion "v"}]
+        ;; Resolve the deferred dispose after current sync + microtask work completes
+        (js/setTimeout (fn [] (@resolve-dispose nil)) 0)
+        (with-redefs [acp/create-connection (fn [_] result)]
+          (-> (initialize-dev (fn [_] nil))
+              (.catch (fn [err]
+                        (is (= "boom" (.-message err)))
+                        (is (= [:dispose-called :dispose-settled] @events)
+                            "rethrow should chain after dispose settles")))
+              (.finally (fn [] (.then (acp/shutdown) (fn [_] (done)))))))))))
+
+(deftest test-shutdown-returns-promise-that-awaits-dispose
+  (testing "shutdown returns a promise that resolves after dispose settles"
+    (async done
+      (let [events          (atom [])
+            resolve-dispose (atom nil)
+            deferred        (js/Promise. (fn [r _] (reset! resolve-dispose r)))
+            conn            #js {:initialize
+                                 (fn [_] (js/Promise.resolve #js {:agentCapabilities #js {}}))}
+            dispose-agent   (fn []
+                              (.then deferred (fn [_] (swap! events conj :dispose-settled))))
+            result          #js {:connection   conn
+                                 :disposeAgent dispose-agent
+                                 :protocolVersion "v"}]
+        (js/setTimeout (fn [] (@resolve-dispose nil)) 0)
+        (with-redefs [acp/create-connection (fn [_] result)]
+          (-> (initialize-dev (fn [_] nil))
+              (.then (fn [_]
+                       (let [p (acp/shutdown)]
+                         (is (instance? js/Promise p)
+                             "shutdown should return a promise")
+                         (-> p
+                             (.then (fn [_]
+                                      (is (= [:dispose-settled] @events)
+                                          "dispose should have settled before shutdown promise resolves")))
+                             (.finally (fn [] (done)))))))
+              (.catch (fn [e] (js/console.error "unexpected error" e) (done)))))))))
+
+(deftest test-initialize-waits-for-shutdown-dispose
+  (testing "initialize called during async shutdown defers until dispose settles"
+    (async done
+      (let [resolve-dispose (atom nil)
+            deferred        (js/Promise. (fn [r _] (reset! resolve-dispose r)))
+            dispose-settled (atom false)
+            conn            #js {:initialize
+                                 (fn [_] (js/Promise.resolve #js {:agentCapabilities #js {}}))}
+            dispose-agent   (fn []
+                              (.then deferred (fn [_] (reset! dispose-settled true))))
+            result          #js {:connection   conn
+                                 :disposeAgent dispose-agent
+                                 :protocolVersion "v"}
+            create-count    (atom 0)]
+        (with-redefs [acp/create-connection (fn [_] (swap! create-count inc) result)]
+          (-> (initialize-dev (fn [_] nil))
+              (.then (fn [_]
+                       (acp/shutdown)
+                       ;; Immediately call initialize while dispose is still pending
+                       (let [init-p (initialize-dev (fn [_] nil))]
+                         ;; KEY: no new connection created synchronously
+                         (is (= 1 @create-count)
+                             "new connection should not be created until dispose settles")
+                         (@resolve-dispose nil)
+                         ;; Wait for init-p to settle (resolve or reject — real create-connection
+                         ;; is used here since with-redefs has unwound for the async retry)
+                         (-> (.allSettled js/Promise #js [init-p])
+                             (.then (fn [_]
+                                      (is (= true @dispose-settled)
+                                          "dispose must settle before init-p can settle")))
+                             (.finally (fn [] (.then (acp/shutdown) (fn [_] (done)))))))))
+              (.catch (fn [e] (js/console.error "unexpected error" e) (done)))))))))


### PR DESCRIPTION
This switches Gremllm's ACP bridge from spawning `claude-agent-acp` as a subprocess to hosting it in-process over paired `TransformStream`s, and wires the packaged Electron launch knobs the pinned adapter needs (`RunAsNode`, `ELECTRON_RUN_AS_NODE=1`, and `settingSources: []`).

It also updates the ACP lifecycle tests to cover async dispose ordering and removes the now-obsolete spike planning artifacts, keeping a single closeout note for the final packaged-host decision.

The main tradeoff is that packaged launches now depend on Electron's `RunAsNode` fuse and the pinned adapter's current `_meta` behavior, so that contract needs to be rechecked on dependency upgrades.

Reference:
Specs and Plans in https://github.com/Quantisan/gremllm/pull/236