### PR TITLE
docs: add source-adjacent architecture READMEs and tighten CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,60 +162,12 @@ Following FCIS principles, all state changes flow through Nexus:
 
 ## IPC & Data
 
-**IPC Channels:**
-- `topic/save` - Persist a topic EDN file
-- `topic/delete` - Delete a topic file after confirmation
-- `document/create` - Create `<workspace>/document.md`
-- `secrets/save` - Encrypt and store a secret in the user data secrets file
-- `secrets/delete` - Delete a stored secret
-- `acp/new-session` - Start a new ACP session
-- `acp/prompt` - Send a user prompt to ACP
-- `acp/resume-session` - Resume a topic-bound ACP session
-- `acp:session-update` - Stream ACP session updates to renderer
-- `workspace/pick-folder` - Folder picker dialog
-- `workspace/reload` - Request refreshed workspace data
-- `workspace:opened` - Broadcast refreshed workspace payload (`onWorkspaceOpened`)
-- `system/get-info` - System capabilities
-- `menu:command` - Broadcast app menu commands into the renderer (`onMenuCommand`)
+IPC channels and workspace layout are documented in `src/gremllm/main/README.md`.
 
-`preload.js` exposes promise-style wrappers for ACP commands and intent-driven listeners like `onWorkspaceOpened`, `onAcpSessionUpdate`, and `onMenuCommand`, so the renderer does not manipulate raw IPC strings directly outside the preload boundary.
-
-**Data Storage:**
-```
-<userData>/User/
-└── secrets.edn              # Encrypted API keys via Electron safeStorage
-
-<workspace-folder>/          # User-selected folder (anywhere)
-├── document.md              # Primary workspace document (created on demand)
-└── topics/
-    └── *.edn                # Topic/session files
-```
-
-- **Workspaces:** Portable folders, like git repos - can live anywhere
-- **Document:** `document.md` is the primary artifact in the current scooter implementation
-- **Topics:** Individual EDN files in `topics/` subdirectory (includes `[:session :id]`, `[:session :pending-diffs]`, and local message history)
-- **Schemas:** See `schema.cljs` for data structures; transport/IPC codecs live in `schema/codec.cljs`
-- **File I/O:** See `main/io.cljs` for paths and operations
-
-## Entry Points
-
-When exploring unfamiliar code, start here and in the Key Namespaces table before running broad searches.
-
-- `src/gremllm/main/core.cljs` - Main process start
-- `src/gremllm/main/actions/acp.cljs` - ACP prompt block construction from structured user messages and staged excerpts
-- `src/gremllm/main/effects/acp.cljs` - ACP connection lifecycle, permission resolution wiring, and native file callbacks
-- `src/gremllm/renderer/core.cljs` - Renderer start
-- `src/gremllm/renderer/ui.cljs` - Main UI components
-- `src/gremllm/renderer/ui/document.cljs` - Document panel rendering
-- `src/gremllm/renderer/ui/document/diffs.cljs` - Pending diff anchoring and composition
-- `src/gremllm/*/actions.cljs` - Action/effect registrations
-- `src/gremllm/schema.cljs` - Data models and validation
-- `src/gremllm/schema/codec.cljs` - IPC/JS/ACP codecs and adapters
-- `src/gremllm/schema/codec/acp_permission.cljs` - Pure ACP permission policy
-- `src/js/acp/index.js` - In-process ACP bridge built on paired `TransformStream`s
-- `resources/public/js/preload.js` - Intent-driven Electron bridge exposed to the renderer
-- `test/gremllm/schema_test.cljs` - Schema validation tests
-- `test/gremllm/renderer/actions/` - Renderer action tests (excerpt, message, etc.)
+Cross-cutting facts:
+- **Workspaces** are portable folders (like git repos) — can live anywhere
+- **Topics** persist `[:session :id]` and `[:session :pending-diffs]` alongside local message history
+- **Canonical data models** live in `src/gremllm/schema.cljs`; boundary coercions and transport shapes live in `src/gremllm/schema/codec.cljs`
 
 ## UI Approach
 - **PicoCSS + split palette** - Semantic HTML with PicoCSS defaults. A TVA/Brutalist palette defines light zones (document panel) and dark zones (nav, chat). Element aliases in `elements.cljs` handle zone scoping automatically — don't set `data-theme` manually.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,34 +34,38 @@ Why PE due diligence:
 ## Architecture
 
 **Process Structure:**
-- `src/gremllm/main/` - Electron main process (IPC, file ops, system integration)
-- `src/gremllm/renderer/` - UI and app logic (browser context)
-- `resources/public/` - Web assets (index.html, compiled JS)
-- `resources/public/js/preload.js` - Preload boundary exposing intent-driven Electron APIs
+- `src/gremllm/main/` - Electron main process: app lifecycle, window/menu setup, IPC registration, file and system boundaries
+- `src/gremllm/renderer/` - Renderer app: Nexus state, Replicant UI, document-first workflows, preload-driven IPC consumption
+- `src/gremllm/schema/` - Shared schema and codec layer for disk, IPC, DOM capture, and ACP transport boundaries
+- `src/js/acp/` - In-process ACP host bridge built on paired `TransformStream`s
+- `resources/public/js/preload.js` - Intent-driven Electron bridge exposed to the renderer
 
-**Key Namespaces Quick Reference:**
+**Operational Map:**
+- Main process owns Electron lifecycle, native integration, workspace and topic persistence, secrets, and ACP connection bootstrap
+- Renderer owns application state, user workflows, document rendering, excerpt capture, and pending diff presentation
+- Schema/codecs own shared contracts and boundary transforms
+- The JS ACP host owns transport wiring; CLJS `main.effects.acp` owns lifecycle, callbacks, and permission resolution
 
-| Domain | Main Process | Renderer Process |
-|--------|--------------|------------------|
-| Actions | `main.actions.*` - effects, IPC | `renderer.actions.*` - UI, messages, settings, topic, workspace |
-| State | - | `renderer.state.*` - ACP, form, messages, UI, system, topic |
-| UI | - | `renderer.ui.*` - chat, settings, topics |
-| Effects | `main.effects.*` - ACP, file I/O | (handled in actions) |
-| Core | `main.core` - app bootstrap, IPC handler registration, window/menu setup | `renderer.core` - renderer bootstrap, IPC listeners, render loop |
-| ACP | `main.actions.acp` - prompt block construction; `main.effects.acp` - in-process connection lifecycle, permission/file callbacks | `renderer.actions.acp` - streaming chunks, tool events, pending diff routing |
-| Workspace & Documents | `main.actions.workspace`, `main.actions.document`, `main.effects.workspace`, `main.state` | `renderer.actions.workspace`, `renderer.actions.document`, `renderer.state.workspace`, `renderer.state.document`, `renderer.ui.document`, `renderer.ui.welcome` |
-| Schema | `schema` - data models, validation | (shared) |
-| Codec | `schema.codec`, `schema.codec.acp-permission` - IPC/JS/ACP adaptation, wire codecs, pure ACP permission policy | (shared) |
+**Detailed Architecture Docs:**
+- `src/gremllm/main/README.md`
+- `src/gremllm/renderer/README.md`
+- `src/gremllm/schema/README.md`
+- `src/js/acp/README.md`
 
-**ACP Integration (current implementation):**
-- Gremllm hosts `claude-agent-acp` in-process through `src/js/acp/index.js`; `main.effects.acp` eagerly initializes and owns the shared ACP connection lifecycle
-- One ACP session per topic; the topic stores the ACP session id at `[:session :id]`
-- Session resume uses ACP resume plus locally persisted topic messages (hybrid history)
-- Prompts are built from structured user messages; staged excerpts render into a References section, and prompts include a `resource_link` to workspace `document.md` when that file exists
-- ACP client capabilities enable `readTextFile` and `writeTextFile`; reads come from disk, while writes are intentionally acknowledged as dry-run so the agent can complete proposal flows without mutating workspace files directly
-- Permission requests are normalized in `schema.codec` and resolved by the pure CLJS policy in `schema.codec.acp-permission`, keeping workspace path checks and approval logic out of the JS transport bridge
-- Streaming session updates flow main → renderer via IPC events; `tool-call-update` diff payloads are normalized in `schema.codec` and accumulated at `[:topics <topic-id> :session :pending-diffs]`
-- **Note:** Current implementation uses a single generic ACP session per topic. Product direction: specialized agents for different tasks (research, analysis, synthesis, etc.). This is a known gap to be addressed.
+**Key Entry Points:**
+- `src/gremllm/main/core.cljs`
+- `src/gremllm/main/actions/acp.cljs`
+- `src/gremllm/main/effects/acp.cljs`
+- `src/gremllm/main/effects/workspace.cljs`
+- `src/gremllm/renderer/core.cljs`
+- `src/gremllm/renderer/actions.cljs`
+- `src/gremllm/renderer/ui/document.cljs`
+- `src/gremllm/renderer/ui/document/diffs.cljs`
+- `src/gremllm/schema.cljs`
+- `src/gremllm/schema/codec.cljs`
+- `src/gremllm/schema/codec/acp_permission.cljs`
+- `src/js/acp/index.js`
+- `resources/public/js/preload.js`
 
 ## Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ These principles guide every implementation decision:
 
 1. **Document-first, not chat-first** - The artifact is the center of gravity, not the conversation history
 2. **Expert judgment and taste are elevated, not hidden** - Where human expertise made the difference is visible and valued
-3. **AI assists through specialized agents you can steer** - Not one generic assistant, but specialized agents for specific tasks
+3. **You direct; the AI writes** - You shape the work by steering, accepting, rejecting, and redirecting changes. The AI does the typing.
 4. **Context is managed, not dumped** - Information is progressively disclosed for each task, not pasted wholesale
 5. **Simple by default, powerful when needed** - Core workflows are straightforward; advanced capabilities available when required
 
@@ -126,16 +126,7 @@ By aligning our code with our mental model, we reduce cognitive load, make the s
 
 ### Vision: An Idea Development Environment for Verified Knowledge Work
 
-Gremllm is an **Idea Development Environment**—a structured workspace where knowledge workers produce artifacts that carry their own proof. The six pillars:
-
-1. **The artifact is the center of gravity** - Document-first, not chat-first. The deliverable is what matters.
-2. **Expert judgment is elevated** - Taste, experience, and intuition are first-class, not hidden. Where the human made the difference is visible and valued.
-3. **AI works through specialized agents** - Not one generic assistant, but steerable agents for specific tasks (research, analysis, synthesis, verification).
-4. **Context is managed, not dumped** - Information is progressively disclosed for each task, not pasted wholesale into a prompt.
-5. **Process is captured as you work** - Evidence, methodology, and reasoning are captured alongside the artifact itself.
-6. **Deliverables carry proof** - Stakeholders can verify the work by examining the methodology, evidence, and expert judgment that produced it.
-
-**The core insight:** The artifact is portable (exported, shared, presented). The proof lives in the platform (methodology, evidence, reasoning, expert judgment).
+Gremllm is an **Idea Development Environment**—a structured workspace where knowledge workers produce artifacts that carry their own proof. The principles above define the working model: the document stays central, expert judgment stays visible, and humans direct the work while AI proposes the writing. As work progresses, Gremllm captures process, evidence, and judgment alongside the artifact so stakeholders can examine not just the deliverable, but how it was produced. **The artifact is portable; the proof lives in the platform.**
 
 ## State Management with Nexus
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,8 @@ Following FCIS principles, all state changes flow through Nexus:
 
 ## Entry Points
 
+When exploring unfamiliar code, start here and in the Key Namespaces table before running broad searches.
+
 - `src/gremllm/main/core.cljs` - Main process start
 - `src/gremllm/main/effects/acp.cljs` - ACP connection lifecycle and native file callbacks
 - `src/gremllm/renderer/core.cljs` - Renderer start
@@ -213,6 +215,8 @@ Following FCIS principles, all state changes flow through Nexus:
 - `src/gremllm/schema.cljs` - Data models and validation
 - `src/gremllm/schema/codec.cljs` - IPC/JS/ACP codecs and adapters
 - `resources/public/js/preload.js` - Intent-driven Electron bridge exposed to the renderer
+- `test/gremllm/schema_test.cljs` - Schema validation tests
+- `test/gremllm/renderer/actions/` - Renderer action tests (excerpt, message, etc.)
 
 ## UI Approach
 - **PicoCSS + split palette** - Semantic HTML with PicoCSS defaults. A TVA/Brutalist palette defines light zones (document panel) and dark zones (nav, chat). Element aliases in `elements.cljs` handle zone scoping automatically — don't set `data-theme` manually.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,18 +48,19 @@ Why PE due diligence:
 | UI | - | `renderer.ui.*` - chat, settings, topics |
 | Effects | `main.effects.*` - ACP, file I/O | (handled in actions) |
 | Core | `main.core` - app bootstrap, IPC handler registration, window/menu setup | `renderer.core` - renderer bootstrap, IPC listeners, render loop |
-| ACP | `main.actions.acp`, `main.effects.acp` - prompt construction, SDK lifecycle, native file callbacks | `renderer.actions.acp` - streaming chunks, tool events, pending diff routing |
+| ACP | `main.actions.acp` - prompt block construction; `main.effects.acp` - in-process connection lifecycle, permission/file callbacks | `renderer.actions.acp` - streaming chunks, tool events, pending diff routing |
 | Workspace & Documents | `main.actions.workspace`, `main.actions.document`, `main.effects.workspace`, `main.state` | `renderer.actions.workspace`, `renderer.actions.document`, `renderer.state.workspace`, `renderer.state.document`, `renderer.ui.document`, `renderer.ui.welcome` |
 | Schema | `schema` - data models, validation | (shared) |
-| Codec | `schema.codec` - IPC/JS/ACP adaptation and codecs | (shared) |
+| Codec | `schema.codec`, `schema.codec.acp-permission` - IPC/JS/ACP adaptation, wire codecs, pure ACP permission policy | (shared) |
 
 **ACP Integration (current implementation):**
+- Gremllm hosts `claude-agent-acp` in-process through `src/js/acp/index.js`; `main.effects.acp` eagerly initializes and owns the shared ACP connection lifecycle
 - One ACP session per topic; the topic stores the ACP session id at `[:session :id]`
 - Session resume uses ACP resume plus locally persisted topic messages (hybrid history)
-- Prompts include a `resource_link` to workspace `document.md` when that file exists
-- ACP client capabilities enable `readTextFile` and dry-run `writeTextFile` callbacks so the agent can read the document and propose edits without mutating disk during proposal capture
-- Streaming session updates flow main → renderer via IPC events
-- `tool-call-update` diff payloads are normalized in `schema.codec` and accumulated at `[:topics <topic-id> :session :pending-diffs]`
+- Prompts are built from structured user messages; staged excerpts render into a References section, and prompts include a `resource_link` to workspace `document.md` when that file exists
+- ACP client capabilities enable `readTextFile` and `writeTextFile`; reads come from disk, while writes are intentionally acknowledged as dry-run so the agent can complete proposal flows without mutating workspace files directly
+- Permission requests are normalized in `schema.codec` and resolved by the pure CLJS policy in `schema.codec.acp-permission`, keeping workspace path checks and approval logic out of the JS transport bridge
+- Streaming session updates flow main → renderer via IPC events; `tool-call-update` diff payloads are normalized in `schema.codec` and accumulated at `[:topics <topic-id> :session :pending-diffs]`
 - **Note:** Current implementation uses a single generic ACP session per topic. Product direction: specialized agents for different tasks (research, analysis, synthesis, etc.). This is a known gap to be addressed.
 
 ## Development
@@ -206,7 +207,8 @@ Following FCIS principles, all state changes flow through Nexus:
 When exploring unfamiliar code, start here and in the Key Namespaces table before running broad searches.
 
 - `src/gremllm/main/core.cljs` - Main process start
-- `src/gremllm/main/effects/acp.cljs` - ACP connection lifecycle and native file callbacks
+- `src/gremllm/main/actions/acp.cljs` - ACP prompt block construction from structured user messages and staged excerpts
+- `src/gremllm/main/effects/acp.cljs` - ACP connection lifecycle, permission resolution wiring, and native file callbacks
 - `src/gremllm/renderer/core.cljs` - Renderer start
 - `src/gremllm/renderer/ui.cljs` - Main UI components
 - `src/gremllm/renderer/ui/document.cljs` - Document panel rendering
@@ -214,6 +216,8 @@ When exploring unfamiliar code, start here and in the Key Namespaces table befor
 - `src/gremllm/*/actions.cljs` - Action/effect registrations
 - `src/gremllm/schema.cljs` - Data models and validation
 - `src/gremllm/schema/codec.cljs` - IPC/JS/ACP codecs and adapters
+- `src/gremllm/schema/codec/acp_permission.cljs` - Pure ACP permission policy
+- `src/js/acp/index.js` - In-process ACP bridge built on paired `TransformStream`s
 - `resources/public/js/preload.js` - Intent-driven Electron bridge exposed to the renderer
 - `test/gremllm/schema_test.cljs` - Schema validation tests
 - `test/gremllm/renderer/actions/` - Renderer action tests (excerpt, message, etc.)

--- a/src/gremllm/main/README.md
+++ b/src/gremllm/main/README.md
@@ -22,6 +22,11 @@ value to `ipcRenderer.invoke`, trace the synchronous pipeline. If it should
 trigger later renderer updates, trace the Nexus-dispatched path and the matching
 IPC event.
 
+Note the mechanism split: `acp/*` handlers use `ipcMain.on` (fire-and-forget;
+no return value, the renderer never awaits the call), while all other handlers —
+including the Nexus-dispatching ones — use `ipcMain.handle`. Renderer state for
+ACP arrives exclusively through the `acp:session-update` event stream.
+
 ## Domain Map
 
 - `core.cljs`: app bootstrap, IPC handler registration, app lifecycle hooks
@@ -61,7 +66,36 @@ Start in `core.cljs` at `document/create`, then follow
 
 Start in `core.cljs` at `acp/new-session`, `acp/resume-session`, or
 `acp/prompt`. Session runtime behavior lives in `main.effects.acp`, while
-prompt content construction lives in `main.actions.acp`.
+prompt content construction lives in `main.actions.acp`. The JS transport bridge
+is at `src/js/acp/index.js`; permission policy is at
+`src/gremllm/schema/codec/acp_permission.cljs`. See those READMEs for details
+on each side of the seam.
+
+## IPC Channels
+
+All handlers are registered in `core.cljs`. The preload bridge (`resources/public/js/preload.js`) exposes promise-style wrappers and intent-driven listeners so the renderer never touches raw IPC strings.
+
+**Topic:** `topic/save`, `topic/delete`
+**Document:** `document/create`
+**Secrets:** `secrets/save`, `secrets/delete`
+**ACP:** `acp/new-session`, `acp/resume-session`, `acp/prompt`, `acp:session-update` (event, main → renderer)
+**Workspace:** `workspace/pick-folder`, `workspace/reload`, `workspace:opened` (event, main → renderer)
+**System:** `system/get-info`
+**Menu:** `menu:command` (event, main → renderer)
+
+## Data Storage
+
+```
+<userData>/User/
+└── secrets.edn              # Encrypted API keys via Electron safeStorage
+
+<workspace-folder>/          # User-selected folder; portable like a git repo
+├── document.md              # Primary workspace artifact (created on demand)
+└── topics/
+    └── *.edn                # One file per topic; includes session id and pending diffs
+```
+
+See `src/gremllm/main/io.cljs` for path helpers and `src/gremllm/schema/codec.cljs` for disk codecs.
 
 ## Entry Points
 

--- a/src/gremllm/main/README.md
+++ b/src/gremllm/main/README.md
@@ -1,0 +1,73 @@
+# Main Process Architecture
+
+## Ownership
+
+The main process owns Electron application lifecycle, native window and menu
+setup, IPC registration, workspace and topic persistence, secrets storage, and
+the CLJS side of ACP connection management.
+
+## Runtime Boundary
+
+Two IPC patterns coexist here:
+
+- synchronous handlers in `core.cljs` return values directly for
+  request-response operations such as topic save, topic delete, document
+  create, secrets operations, and system info
+- asynchronous handlers in `core.cljs` dispatch Nexus actions for workflows
+  whose results return later over IPC events, such as workspace loading and ACP
+  session operations
+
+This split is operationally important. If a change must return an immediate
+value to `ipcRenderer.invoke`, trace the synchronous pipeline. If it should
+trigger later renderer updates, trace the Nexus-dispatched path and the matching
+IPC event.
+
+## Domain Map
+
+- `core.cljs`: app bootstrap, IPC handler registration, app lifecycle hooks
+- `actions.cljs`: Nexus action and effect registration for main-process
+  behavior
+- `actions/`: pure planning helpers for ACP prompt content, documents, topics,
+  secrets, and workspace actions
+- `effects/`: imperative file I/O, dialogs, IPC replies, ACP runtime
+  integration, attachment storage
+- `window.cljs`: BrowserWindow sizing, preload wiring, and close handling
+- `menu.cljs`: native menu template and dispatch into renderer-facing commands
+- `io.cljs`: path helpers and file utilities
+- `state.cljs`: workspace-directory lookup used by IPC handlers
+
+## Hot Paths
+
+### Workspace Open Or Reload
+
+Start in `core.cljs` at `workspace/reload` or `workspace/pick-folder`, then
+follow `main.actions.workspace` and `main.effects.workspace/load-and-sync`,
+which reads `document.md`, loads `topics/*.edn`, and pushes `workspace:opened`
+to the renderer.
+
+### Topic Save Or Delete
+
+Start in `core.cljs` at `topic/save` or `topic/delete`, then follow
+`main.actions.topic` for the pure save or delete plan and
+`main.effects.workspace` for the disk effect.
+
+### Document Create
+
+Start in `core.cljs` at `document/create`, then follow
+`main.actions.document/create-plan` and
+`main.effects.workspace/create-document`.
+
+### ACP Session Operations
+
+Start in `core.cljs` at `acp/new-session`, `acp/resume-session`, or
+`acp/prompt`. Session runtime behavior lives in `main.effects.acp`, while
+prompt content construction lives in `main.actions.acp`.
+
+## Entry Points
+
+- `src/gremllm/main/core.cljs`
+- `src/gremllm/main/actions.cljs`
+- `src/gremllm/main/effects/workspace.cljs`
+- `src/gremllm/main/effects/acp.cljs`
+- `src/gremllm/main/window.cljs`
+- `src/gremllm/main/menu.cljs`

--- a/src/gremllm/renderer/README.md
+++ b/src/gremllm/renderer/README.md
@@ -36,14 +36,17 @@ topic map, and document content.
 
 ### Prompt Submission
 
-Start in `renderer.actions.ui/submit-messages`, which builds the structured
-user message, dispatches chat updates, and calls
+Dispatched as `:form.actions/submit` (registered in `renderer/actions.cljs`),
+which calls `renderer.actions.ui/submit-messages`. That function builds the
+structured user message, dispatches chat updates, and calls
 `renderer.actions.acp/send-prompt`.
 
 ### Streaming Session Updates
 
 Start in `renderer.actions.acp/session-update`, which routes assistant chunks,
 reasoning chunks, tool events, and pending diff accumulation into topic state.
+The `AcpUpdate` coercion happens at the IPC boundary in
+`src/gremllm/schema/codec.cljs` before the update reaches this action.
 
 ### Excerpt Capture And Document Review
 
@@ -51,6 +54,13 @@ Start in `renderer.ui.document`, `renderer.actions.excerpt`, and
 `renderer.ui.document.locator`. Selection capture originates from the document
 panel, durable excerpt data is stored on the active topic, and highlights are
 re-synced after markdown re-render.
+
+### Menu Commands
+
+`onMenuCommand` listener in `renderer/core.cljs` routes `:save-topic` and
+`:show-settings` keywords from the main-process menu into Nexus dispatches.
+This lives in `core.cljs` (not `actions/`) because it is a preload-event
+subscription wired at bootstrap, not a domain action.
 
 ## Entry Points
 
@@ -63,3 +73,7 @@ re-synced after markdown re-render.
 - `src/gremllm/renderer/ui/document/diffs.cljs`
 - `src/gremllm/renderer/ui/document/locator.cljs`
 - `src/gremllm/renderer/ui/document/highlights.cljs`
+
+## Tests
+
+- `test/gremllm/renderer/actions/` — renderer action tests (excerpt, message, etc.)

--- a/src/gremllm/renderer/README.md
+++ b/src/gremllm/renderer/README.md
@@ -1,0 +1,65 @@
+# Renderer Architecture
+
+## Ownership
+
+The renderer owns the Nexus store, Replicant rendering, preload-driven IPC
+consumption, topic and document state, and the document-first user workflows
+that tie chat activity back to `document.md`.
+
+## Structure
+
+- `core.cljs`: renderer bootstrap, IPC listeners, render loop, initial dispatch
+- `actions.cljs`: action and effect registration, DOM placeholders, promise
+  handling, store-level effects
+- `actions/`: domain actions for UI, workspace, topics, messages, ACP,
+  excerpts, settings, and document state
+- `state/`: focused selectors and paths for document, workspace, topic, form,
+  excerpt, loading, sensitive, system, and UI state
+- `ui.cljs`: app-level composition
+- `ui/`: chat, topics, settings, welcome, markdown, and document views
+- `ui/document/`: source-aware helpers for diff composition, source locator
+  metadata, and excerpt highlighting
+
+## Hot Paths
+
+### App Bootstrap
+
+Start in `core.cljs`, which wires preload listeners for `workspace:opened`,
+`acp:session-update`, and `menu:command`, installs the render watcher, and
+dispatches initial system and workspace actions.
+
+### Workspace Hydration
+
+Follow `renderer.actions.workspace/opened`, which normalizes the
+`workspace:opened` payload into renderer state including workspace metadata,
+topic map, and document content.
+
+### Prompt Submission
+
+Start in `renderer.actions.ui/submit-messages`, which builds the structured
+user message, dispatches chat updates, and calls
+`renderer.actions.acp/send-prompt`.
+
+### Streaming Session Updates
+
+Start in `renderer.actions.acp/session-update`, which routes assistant chunks,
+reasoning chunks, tool events, and pending diff accumulation into topic state.
+
+### Excerpt Capture And Document Review
+
+Start in `renderer.ui.document`, `renderer.actions.excerpt`, and
+`renderer.ui.document.locator`. Selection capture originates from the document
+panel, durable excerpt data is stored on the active topic, and highlights are
+re-synced after markdown re-render.
+
+## Entry Points
+
+- `src/gremllm/renderer/core.cljs`
+- `src/gremllm/renderer/actions.cljs`
+- `src/gremllm/renderer/actions/ui.cljs`
+- `src/gremllm/renderer/actions/acp.cljs`
+- `src/gremllm/renderer/actions/excerpt.cljs`
+- `src/gremllm/renderer/ui/document.cljs`
+- `src/gremllm/renderer/ui/document/diffs.cljs`
+- `src/gremllm/renderer/ui/document/locator.cljs`
+- `src/gremllm/renderer/ui/document/highlights.cljs`

--- a/src/gremllm/schema/README.md
+++ b/src/gremllm/schema/README.md
@@ -24,16 +24,33 @@ process, or JS boundaries needs validation or translation.
 
 ## Important Shapes
 
+Shapes are labeled by role; file location follows from that.
+
+**In-memory canonical** (`schema.cljs`):
 - `Message`: structured user or assistant chat item, including optional excerpt
   context and attachments
 - `DocumentExcerpt`: durable excerpt reference stored on a topic
-- `PersistedTopic` and `Topic`: disk shape versus in-memory shape
 - `AcpSession`: session id plus pending diffs
+- `Topic`: in-memory representation of a topic and its session state
+
+**Persisted (disk)** (`schema.cljs`):
+- `PersistedTopic`: EDN shape written to `topics/*.edn`
+
+**Transmitted (boundary adapter)** (`schema/codec.cljs`):
 - `WorkspaceSyncData`: payload sent from main to renderer during workspace
-  hydration
+  hydration; defined and coerced at the IPC boundary, not in the canonical
+  schema
+
+**Policy** (`schema/codec/acp_permission.cljs`):
+- Permission decision inputs used by `main.effects.acp` to resolve ACP
+  permission requests without involving the JS transport bridge
 
 ## Entry Points
 
 - `src/gremllm/schema.cljs`
 - `src/gremllm/schema/codec.cljs`
 - `src/gremllm/schema/codec/acp_permission.cljs`
+
+## Tests
+
+- `test/gremllm/schema_test.cljs` — schema validation tests

--- a/src/gremllm/schema/README.md
+++ b/src/gremllm/schema/README.md
@@ -1,0 +1,39 @@
+# Shared Schema And Codec Architecture
+
+## Ownership
+
+This boundary owns the data contracts shared across persistence, IPC, DOM
+capture, and ACP transport. It is the place to look when a shape crossing disk,
+process, or JS boundaries needs validation or translation.
+
+## Files
+
+- `src/gremllm/schema.cljs`: canonical data models for messages, attachments,
+  excerpts, topics, sessions, and workspace-level structures
+- `src/gremllm/schema/codec.cljs`: boundary adapters for disk, IPC, DOM
+  selection capture, ACP session updates, and system info
+- `src/gremllm/schema/codec/acp_permission.cljs`: pure permission policy used
+  by `main.effects.acp`
+
+## Operational Rules
+
+- add or change the canonical shape in `schema.cljs`
+- add boundary-specific coercion or transport transforms in `codec.cljs`
+- keep path and permission decision logic in `codec/acp_permission.cljs` when
+  it must stay pure and reusable
+
+## Important Shapes
+
+- `Message`: structured user or assistant chat item, including optional excerpt
+  context and attachments
+- `DocumentExcerpt`: durable excerpt reference stored on a topic
+- `PersistedTopic` and `Topic`: disk shape versus in-memory shape
+- `AcpSession`: session id plus pending diffs
+- `WorkspaceSyncData`: payload sent from main to renderer during workspace
+  hydration
+
+## Entry Points
+
+- `src/gremllm/schema.cljs`
+- `src/gremllm/schema/codec.cljs`
+- `src/gremllm/schema/codec/acp_permission.cljs`

--- a/src/js/acp/README.md
+++ b/src/js/acp/README.md
@@ -19,6 +19,9 @@ SDK client and the in-process agent over ndjson streams.
 - `src/gremllm/main/effects/acp.cljs`: initialization, handshake, permission
   resolution, file-read callback wiring, session update dispatch, prompt and
   session APIs
+- `src/gremllm/schema/codec/acp_permission.cljs`: pure CLJS permission policy
+  invoked by `main.effects.acp`; keeps workspace-path checks and approval
+  logic out of the JS transport bridge
 
 ## Dry-Run Write Behavior
 

--- a/src/js/acp/README.md
+++ b/src/js/acp/README.md
@@ -1,0 +1,34 @@
+# ACP Host Architecture
+
+## Ownership
+
+`src/js/acp/index.js` owns the in-process transport bridge between Gremllm and
+`claude-agent-acp`. It is intentionally small: CLJS owns lifecycle and policy,
+while this JS module owns stream wiring and connection-local transport state.
+
+## Why This Exists
+
+Gremllm hosts ACP in-process instead of spawning a separate subprocess
+transport. The bridge uses paired `TransformStream` instances to connect the ACP
+SDK client and the in-process agent over ndjson streams.
+
+## Division Of Responsibility
+
+- `src/js/acp/index.js`: stream bridge, `ClientSideConnection`,
+  `AgentSideConnection`, session cwd tracking, dry-run `writeTextFile`
+- `src/gremllm/main/effects/acp.cljs`: initialization, handshake, permission
+  resolution, file-read callback wiring, session update dispatch, prompt and
+  session APIs
+
+## Dry-Run Write Behavior
+
+`writeTextFile` intentionally acknowledges writes without mutating disk. That
+keeps the agent on the proposal path so it can return a reviewable diff, while
+Gremllm remains in control of whether changes are later accepted or rejected
+through its own workflow.
+
+## Entry Points
+
+- `src/js/acp/index.js`
+- `src/gremllm/main/effects/acp.cljs`
+- `src/gremllm/schema/codec/acp_permission.cljs`


### PR DESCRIPTION
This adds architecture READMEs for the main process, renderer, schema/codec layer, and in-process ACP host, and updates CLAUDE.md to point contributors at those source-adjacent guides. It makes the Electron, renderer, IPC, and ACP boundaries easier to trace without keeping a large duplicated architecture map in one top-level doc. The tradeoff is that architecture context now lives across multiple docs, but each guide stays closer to the code it describes.