### PR TITLE
feat(acp): auto-permit WebSearch permission requests

### DIFF
--- a/src/gremllm/schema/codec/acp.cljs
+++ b/src/gremllm/schema/codec/acp.cljs
@@ -251,11 +251,15 @@
 (def AcpPermissionToolCall
   "Tool call context within an ACP permission request.
    Per ACP SDK, RequestPermissionRequest.toolCall is ToolCallUpdate.
-   Consumer: acp-permission/resolve-permission reads :kind and (on \"edit\")
-   :raw-input.:path / :raw-input.:file-path."
+   Consumer: acp-permission/resolve-permission reads :kind, :tool-name (on
+   \"fetch\"), and (on \"edit\") :raw-input.:path / :raw-input.:file-path.
+   :tool-name is enrichment-populated by acp-permission/enrich-permission-params
+   from prior tool_call session updates (_meta.claudeCode.toolName); the SDK
+   does not send it on the requestPermission wire."
   [:map
    [:tool-call-id              :string]
    [:kind                      AcpToolKind]
+   [:tool-name {:optional true} :string]
    [:raw-input {:optional true} AcpPermissionRawInput]])
 
 (def AcpPermissionRequest

--- a/src/gremllm/schema/codec/acp/permission.cljs
+++ b/src/gremllm/schema/codec/acp/permission.cljs
@@ -97,7 +97,6 @@
           (let [opt (select-option options ["reject_once" "reject_always"] last)]
             {:outcome {:outcome "selected" :option-id (:option-id opt)}}))
 
-        ;; Default: reject.
+        ;; Default: no policy defined for this kind yet — reject until classified.
         (let [opt (select-option options ["reject_once" "reject_always"] last)]
           {:outcome {:outcome "selected" :option-id (:option-id opt)}})))))
-

--- a/src/gremllm/schema/codec/acp/permission.cljs
+++ b/src/gremllm/schema/codec/acp/permission.cljs
@@ -86,6 +86,18 @@
             (let [opt (select-option options ["reject_once" "reject_always"] last)]
               {:outcome {:outcome "selected" :option-id (:option-id opt)}})))
 
+        "fetch"
+        ;; WebSearch is read-only and idempotent; mirror the "read" policy
+        ;; (prefer allow_always, fall back to allow_once). Any other fetch
+        ;; tool (notably WebFetch) falls through to reject — round 2 will
+        ;; route those to a renderer-side permission dialog.
+        (if (= "WebSearch" (requested-tool-name tool-call))
+          (let [opt (select-option options ["allow_always" "allow_once"] first)]
+            {:outcome {:outcome "selected" :option-id (:option-id opt)}})
+          (let [opt (select-option options ["reject_once" "reject_always"] last)]
+            {:outcome {:outcome "selected" :option-id (:option-id opt)}}))
+
         ;; Default: reject.
         (let [opt (select-option options ["reject_once" "reject_always"] last)]
           {:outcome {:outcome "selected" :option-id (:option-id opt)}})))))
+

--- a/test/gremllm/schema/codec/acp/permission_test.cljs
+++ b/test/gremllm/schema/codec/acp/permission_test.cljs
@@ -158,7 +158,7 @@
       (is (= "toolu_ws_02" (get-in result [:tool-call :tool-call-id])))
       (is (nil? (get-in result [:tool-call :locations])))))
 
-  (testing "resolver rejects fetch-kind tool by default"
+  (testing "resolver rejects fetch-kind tool when tool-name absent (enrichment not available)"
     (let [path-mod    (js/require "path")
           cwd         (.resolve path-mod (.cwd js/process) "resources")
           options     (full-options-js)

--- a/test/gremllm/schema/codec/acp/permission_test.cljs
+++ b/test/gremllm/schema/codec/acp/permission_test.cljs
@@ -109,6 +109,16 @@
              (option-id (acp-permission/resolve-permission
                           (make-req "edit" "mcp__acp__Edit" #js {:path file-in-cwd})
                           nil)))))
+    (testing "WebSearch fetch tool call is allowed"
+      (is (= "allow-always"
+             (option-id (acp-permission/resolve-permission
+                          (make-req "fetch" "WebSearch" #js {:query "latest news"})
+                          cwd)))))
+    (testing "WebFetch fetch tool call is rejected (round-2 contract)"
+      (is (= "reject-once"
+             (option-id (acp-permission/resolve-permission
+                          (make-req "fetch" "WebFetch" #js {:url "https://example.com"})
+                          cwd)))))
     (testing "empty options yields cancelled"
       (is (= "cancelled"
              (get-in (acp-permission/resolve-permission


### PR DESCRIPTION
Adds ACP permission schema support for enriched fetch tool names and uses that enrichment to auto-allow WebSearch while continuing to reject WebFetch and unknown fetch requests. This lets the agent perform read-only web searches without interrupting the document workflow, while preserving the stricter permission path for URL fetches. Tests cover the WebSearch allow path, WebFetch rejection, and the missing tool-name fallback.