### PR TITLE
feat(acp): spike propose-then-execute write permission flow

### DIFF
--- a/resources/public/js/preload.js
+++ b/resources/public/js/preload.js
@@ -54,6 +54,17 @@ const acpResumeSession = createIPCBoundary("acp/resume-session");
  */
 const acpPrompt = createIPCBoundary("acp/prompt");
 
+/**
+ * Notifies the main process of the user's accept/reject choice for an ACP
+ * permission request previously surfaced via onAcpPermissionPending. Fire-and-forget.
+ *
+ * @param {{toolCallId: string, optionId: string}} params
+ */
+const acpResolvePermission = ({ toolCallId, optionId }) => {
+	const ipcCorrelationId = crypto.randomUUID();
+	ipcRenderer.send("acp/resolve-permission", ipcCorrelationId, toolCallId, optionId);
+};
+
 contextBridge.exposeInMainWorld("electronAPI", {
 	saveTopic: (topicData) => ipcRenderer.invoke("topic/save", topicData),
 	deleteTopic: (topicId) => ipcRenderer.invoke("topic/delete", topicId),
@@ -63,10 +74,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	onMenuCommand: (callback) => ipcRenderer.on("menu:command", callback),
 	onWorkspaceOpened: (callback) => ipcRenderer.on("workspace:opened", callback),
 	onAcpSessionUpdate: (callback) => ipcRenderer.on("acp:session-update", callback),
+	onAcpPermissionPending: (callback) => ipcRenderer.on("acp:permission-pending", callback),
 	// File path API - uses webUtils.getPathForFile to get filesystem paths from File objects
 	getFilePath: (file) => webUtils.getPathForFile(file),
 	// ACP API
 	acpNewSession,
 	acpResumeSession,
 	acpPrompt,
+	acpResolvePermission,
 });

--- a/src/gremllm/main/actions.cljs
+++ b/src/gremllm/main/actions.cljs
@@ -84,6 +84,16 @@
     (js/console.log "[ACP→IPC] Pushing session update to acp-session-id:" acp-session-id)
     [[:ipc.effects/send-to-renderer "acp:session-update" event-data]]))
 
+(nxr/register-action! :acp.events/permission-pending
+  (fn [_state enriched]
+    (js/console.log "[ACP→IPC] Pushing permission-pending tool-call-id:"
+                    (get-in enriched [:tool-call :tool-call-id]))
+    [[:ipc.effects/send-to-renderer "acp:permission-pending" enriched]]))
+
+(nxr/register-effect! :acp.effects/resolve-permission
+  (fn [_ _ tool-call-id option-id]
+    (acp-effects/resolve-pending-permission! tool-call-id option-id)))
+
 ;; ACP Effects Registration
 ;; ========================
 

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -97,19 +97,27 @@
          (nxr/dispatch store {:ipc-event event
                               :ipc-correlation-id ipc-correlation-id
                               :channel "acp/prompt"}
-                       [[:acp.effects/send-prompt acp-session-id (codec/user-message-from-ipc message) (state/get-workspace-dir @store)]]))))
+                       [[:acp.effects/send-prompt acp-session-id (codec/user-message-from-ipc message) (state/get-workspace-dir @store)]])))
+
+  (.on ipcMain "acp/resolve-permission"
+       ;; Fire-and-forget: renderer notifies main of user's accept/reject choice;
+       ;; main resolves the pending Promise the SDK is awaiting.
+       (fn [_event _ipc-correlation-id tool-call-id option-id]
+         (nxr/dispatch store {}
+                       [[:acp.effects/resolve-permission tool-call-id option-id]]))))
 
 (defn- setup-system-resources [store]
   (register-domain-handlers store)
   (menu/create-menu store)
   ;; Initialize ACP in-process agent eagerly at launch.
-  ;; Session update callback receives raw JS params from SDK, coerces
-  ;; via codec, and dispatches as a Nexus action.
-  ;;
-  ;; NOTE: Direct call, not a Nexus effect. Bootstrap infrastructure differs
-  ;; from runtime capabilities - other ACP effects handle user operations.
+  ;; Session updates and permission-pending events both flow into Nexus actions
+  ;; that fan out to the renderer via IPC.
   (acp-effects/initialize
-    {:on-session-update (acp-effects/make-session-update-callback store nil)}))
+    {:on-session-update
+     (acp-effects/make-session-update-callback store nil)
+     :on-pending-permission
+     (fn [enriched]
+       (nxr/dispatch store {} [[:acp.events/permission-pending enriched]]))}))
 
 (defn- initialize-app [store]
   (setup-system-resources store)

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -34,6 +34,35 @@
 ;;    :ready         <init-promise>}
 (defonce ^:private state (atom nil))
 
+;; Resolvers for ACP requestPermission calls awaiting user input.
+;; Keyed by ACP tool-call-id. Each entry is a 1-arg fn that takes a
+;; permission outcome (e.g. "allow_once", "reject_once") and resolves the
+;; pending JS Promise returned to the SDK from resolve-cb.
+(defonce ^:private pending-permissions (atom {}))
+
+(defn stash-pending-permission!
+  "Register a resolver for a pending ACP permission request. If an entry
+   already exists for tool-call-id the prior resolver is discarded (and
+   the awaiting SDK Promise will hang); this is unexpected and logged."
+  [tool-call-id resolver]
+  (when (contains? @pending-permissions tool-call-id)
+    (js/console.warn "[ACP] replacing pending permission resolver for" tool-call-id))
+  (swap! pending-permissions assoc tool-call-id resolver))
+
+(defn resolve-pending-permission!
+  "Fire the registered resolver for tool-call-id with the given option-id
+   (e.g. \"allow_once\", \"reject_once\"). No-op if no resolver is registered."
+  [tool-call-id option-id]
+  (when-let [resolver (get @pending-permissions tool-call-id)]
+    (swap! pending-permissions dissoc tool-call-id)
+    (resolver option-id)
+    nil))
+
+(defn pending-permission-snapshot
+  "Snapshot of the current pending-permissions map. For tests/inspection."
+  []
+  @pending-permissions)
+
 (defn slice-content-by-lines
   "Slice string content by 1-indexed line offset and limit.
    Returns full content when both line and limit are nil."

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -247,6 +247,7 @@
   "Tear down in-process ACP agent. Returns a promise that resolves after dispose
    settles so callers (e.g. a before-quit hook) can await cleanup."
   []
+  (reset! pending-permissions {})
   (if-let [{:keys [dispose-agent]} @state]
     (do (reset! state nil)
         (dispose-agent))

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -114,7 +114,7 @@
   #js {:name "gremllm" :title "Gremllm" :version "0.1.0"})
 
 (def ^:private client-capabilities
-  #js {:fs       #js {:readTextFile true :writeTextFile true}
+  #js {:fs       #js {:readTextFile true :writeTextFile false}
        :terminal false})
 
 (defn- start-connection!
@@ -137,19 +137,6 @@
                                (throw err))))
                   (throw err))))))
 
-(defn- make-write-callback
-  "Build a fire-and-forget write tap. Coerces raw JS params and
-   calls on-write with a map of :path, :session-id, :content-length."
-  [on-write]
-  (fn [params]
-    (try
-      (on-write {:path           (.-path params)
-                 :session-id     (.-sessionId params)
-                 :content-length (when (string? (.-content params))
-                                   (.-length (.-content params)))})
-      (catch :default e
-        (js/console.error "ACP write request coercion failed" e params)))))
-
 (defn initialize
   "Initialize ACP connection eagerly. Idempotent.
    opts keys:
@@ -159,9 +146,8 @@
                             when the resolver defers to user input (in-workspace edit).
                             Fires *after* the resolver is registered, so a synchronous call
                             to resolve-pending-permission! from inside this callback (e.g.
-                            from tests) resolves the SDK Promise correctly.
-     :on-write              optional tap receiving coerced writeTextFile params."
-  [{:keys [on-session-update on-permission on-pending-permission on-write]}]
+                            from tests) resolves the SDK Promise correctly."
+  [{:keys [on-session-update on-permission on-pending-permission]}]
   (if-let [ready (:ready @state)]
     ready
     (let [;; Per-connection tool-name tracker. Seeded from session updates so
@@ -212,7 +198,6 @@
           ^js result   (create-connection
                          #js {:onSessionUpdate   session-cb
                               :onReadTextFile    read-text-file
-                              :onWriteTextFile   (when on-write (make-write-callback on-write))
                               :resolvePermission resolve-cb})
           dispose-agent (.-disposeAgent result)
           ready-promise (start-connection! (.-connection result)

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -157,8 +157,9 @@
      :on-permission         optional tap receiving coerced+enriched permission request params.
      :on-pending-permission optional callback receiving enriched permission request params
                             when the resolver defers to user input (in-workspace edit).
-                            Fires *before* the resolver Promise is returned so the renderer
-                            can surface the pending diff alongside the registered resolver.
+                            Fires *after* the resolver is registered, so a synchronous call
+                            to resolve-pending-permission! from inside this callback (e.g.
+                            from tests) resolves the SDK Promise correctly.
      :on-write              optional tap receiving coerced writeTextFile params."
   [{:keys [on-session-update on-permission on-pending-permission on-write]}]
   (if-let [ready (:ready @state)]
@@ -190,20 +191,21 @@
                                  {:outcome (:outcome result)})
 
                                :deferred
-                               (let [tool-call-id (:tool-call-id result)]
+                               (let [tool-call-id  (:tool-call-id result)
+                                     pending-promise (js/Promise.
+                                                       (fn [resolve _reject]
+                                                         (stash-pending-permission!
+                                                           tool-call-id
+                                                           (fn [option-id]
+                                                             (resolve
+                                                               (acp-codec/acp-permission-outcome-to-js
+                                                                 {:outcome {:outcome   "selected"
+                                                                            :option-id option-id}}))))))]
                                  (when on-pending-permission
                                    (try (on-pending-permission enriched)
                                         (catch :default e
                                           (js/console.error "ACP on-pending-permission tap failed" e))))
-                                 (js/Promise.
-                                   (fn [resolve _reject]
-                                     (stash-pending-permission!
-                                       tool-call-id
-                                       (fn [option-id]
-                                         (resolve
-                                           (acp-codec/acp-permission-outcome-to-js
-                                             {:outcome {:outcome   "selected"
-                                                        :option-id option-id}})))))))))
+                                 pending-promise)))
                            (catch :default e
                              (js/console.error "ACP permission resolve failed" e "raw params:" raw-params)
                              #js {:outcome #js {:outcome "cancelled"}})))

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -14,10 +14,14 @@
 ;; so :executable cannot be overridden here.
 ;; ELECTRON_RUN_AS_NODE=1 makes process.execPath act as Node instead of relaunching the window;
 ;; depends on FuseV1Options.RunAsNode (https://packages.electronjs.org/fuses).
+;;
+;; :disallowedTools still blocks MultiEdit/NotebookEdit because the SDK does not
+;; populate diff content in their session/request_permission payload (verified in
+;; node_modules/@agentclientprotocol/claude-agent-acp/dist/tools.js — neither case
+;; exists, so they fall through to the default branch which emits no :diff blocks).
+;; Edit/Write are intentionally allowed: they ARE handled by toolInfoFromToolUse,
+;; so the deferred-permission flow can route their proposed diff to the user.
 ;; SDK refs: sdk.d.ts:56 (model aliases), sdk.d.ts:5371 (ThinkingEnabled).
-;; :disallowedTools blocks the Claude Code subprocess's built-in Edit/Write/MultiEdit/NotebookEdit
-;; before they bypass the bridge's writeTextFile dry-run by writing disk via Node fs.
-;; Merged at acp-agent.js:1379; allowedTools does not work for built-ins (sdk-typescript#115).
 (def ^:private session-meta
   #js {:claudeCode
        #js {:options
@@ -25,7 +29,7 @@
                  :settingSources  #js []
                  :model           "sonnet"
                  :thinking        #js {:type "enabled" :budgetTokens 20480 :display "summarized"}
-                 :disallowedTools #js ["Edit" "Write" "MultiEdit" "NotebookEdit"]}}})
+                 :disallowedTools #js ["MultiEdit" "NotebookEdit"]}}})
 
 ;; TODO: consider adopting https://github.com/stuartsierra/component
 ;; @state is nil, or:

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -149,10 +149,14 @@
 (defn initialize
   "Initialize ACP connection eagerly. Idempotent.
    opts keys:
-     :on-session-update  callback receiving raw JS session update params from SDK.
-     :on-permission      optional tap receiving coerced+enriched permission request params.
-     :on-write           optional tap receiving coerced writeTextFile params."
-  [{:keys [on-session-update on-permission on-write]}]
+     :on-session-update     callback receiving raw JS session update params from SDK.
+     :on-permission         optional tap receiving coerced+enriched permission request params.
+     :on-pending-permission optional callback receiving enriched permission request params
+                            when the resolver defers to user input (in-workspace edit).
+                            Fires *before* the resolver Promise is returned so the renderer
+                            can surface the pending diff alongside the registered resolver.
+     :on-write              optional tap receiving coerced writeTextFile params."
+  [{:keys [on-session-update on-permission on-pending-permission on-write]}]
   (if-let [ready (:ready @state)]
     ready
     (let [;; Per-connection tool-name tracker. Seeded from session updates so
@@ -171,12 +175,31 @@
                            (let [enriched (->> raw-params
                                                acp-codec/acp-permission-request-from-js
                                                (acp-permission/enrich-permission-params @tool-names))
-                                 outcome  (acp-permission/resolve-permission enriched session-cwd)]
+                                 result   (acp-permission/resolve-permission enriched session-cwd)]
                              (when on-permission
                                (try (on-permission enriched)
                                     (catch :default e
                                       (js/console.error "ACP on-permission tap failed (non-fatal; resolved outcome is unaffected)" e))))
-                             (acp-codec/acp-permission-outcome-to-js outcome))
+                             (case (:resolution result)
+                               :immediate
+                               (acp-codec/acp-permission-outcome-to-js
+                                 {:outcome (:outcome result)})
+
+                               :deferred
+                               (let [tool-call-id (:tool-call-id result)]
+                                 (when on-pending-permission
+                                   (try (on-pending-permission enriched)
+                                        (catch :default e
+                                          (js/console.error "ACP on-pending-permission tap failed" e))))
+                                 (js/Promise.
+                                   (fn [resolve _reject]
+                                     (stash-pending-permission!
+                                       tool-call-id
+                                       (fn [option-id]
+                                         (resolve
+                                           (acp-codec/acp-permission-outcome-to-js
+                                             {:outcome {:outcome   "selected"
+                                                        :option-id option-id}})))))))))
                            (catch :default e
                              (js/console.error "ACP permission resolve failed" e "raw params:" raw-params)
                              #js {:outcome #js {:outcome "cancelled"}})))

--- a/src/gremllm/renderer/actions.cljs
+++ b/src/gremllm/renderer/actions.cljs
@@ -134,6 +134,13 @@
   (fn [_ _]
     (.reloadWorkspace js/window.electronAPI)))
 
+;; ACP: forward user's accept/reject for a pending permission to the main process.
+(nxr/register-effect! :acp.effects/resolve-permission
+  (fn [_ _ tool-call-id option-id]
+    (.acpResolvePermission js/window.electronAPI
+                           #js {:toolCallId tool-call-id
+                                :optionId   option-id})))
+
 ;; UI
 (nxr/register-action! :form.actions/update-input ui/update-input)
 (nxr/register-action! :form.actions/clear-input ui/clear-input)
@@ -174,6 +181,9 @@
 
 ;; Register all topic actions
 (nxr/register-action! :topic.actions/append-pending-diffs topic/append-pending-diffs)
+(nxr/register-action! :topic.actions/append-pending-permission topic/append-pending-permission)
+(nxr/register-action! :topic.actions/accept-diff topic/accept-diff)
+(nxr/register-action! :topic.actions/reject-diff topic/reject-diff)
 (nxr/register-action! :tool-call.actions/start  tool-call/start-tool-call)
 (nxr/register-action! :tool-call.actions/update tool-call/update-tool-call)
 (nxr/register-action! :topic.actions/start-new topic/start-new-topic)

--- a/src/gremllm/renderer/actions/acp.cljs
+++ b/src/gremllm/renderer/actions/acp.cljs
@@ -68,9 +68,16 @@
      :text             (acp-codec/acp-read-display-label update)}]])
 
 (defn append-edit-diffs
-  "Appends pending diffs extracted from an Edit/Write tool-call-update's content."
-  [_state update]
-  [[:topic.actions/append-pending-diffs (acp-codec/edit-diffs update)]])
+  "Appends pending diffs extracted from an Edit/Write tool-call-update's content.
+   Skips updates whose tool-call-id was already resolved via accept/reject — the
+   propose-then-execute path stashes the diff at requestPermission time, then the
+   SDK's PostToolUse hook re-emits the same diff after disk write completes."
+  [state update]
+  (let [topic-id     (topic-state/get-active-topic-id state)
+        tool-call-id (:tool-call-id update)
+        resolved     (topic-state/get-resolved-tool-calls state topic-id)]
+    (when-not (contains? resolved tool-call-id)
+      [[:topic.actions/append-pending-diffs (acp-codec/edit-diffs update)]])))
 
 (defn session-update
   "Routes incoming ACP session updates to the matching chat-state operation.

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -66,45 +66,67 @@
     [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing diffs)]]))
 
 (defn append-pending-permission
-  "Add the diffs from an enriched ACP permission request to the active topic's
-   pending-diffs, tagging each with :tool-call-id so accept/reject can resolve
-   the right pending Promise. Returns nil when the permission carries no diffs."
+  "Records an ACP permission request against the active topic: tags each diff
+   in :content with :tool-call-id (so accept/reject can resolve the right
+   pending Promise) and stashes the request's :options under
+   :pending-permission-options keyed by :tool-call-id (so accept/reject can
+   map ACP :kind to the agent-defined :option-id). No-op when no diffs."
   [state enriched]
   (let [{:keys [tool-call-id content]} (:tool-call enriched)
         diffs (when content (filterv #(= "diff" (:type %)) content))]
     (when (seq diffs)
       (let [topic-id (topic-state/get-active-topic-id state)
             existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])
-            tagged   (mapv #(assoc % :tool-call-id tool-call-id) diffs)]
-        [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing tagged)]]))))
+            tagged   (mapv #(assoc % :tool-call-id tool-call-id) diffs)
+            options-map (or (get-in state (topic-state/pending-permission-options-path topic-id)) {})]
+        [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing tagged)]
+         [:effects/save (topic-state/pending-permission-options-path topic-id)
+          (assoc options-map tool-call-id (:options enriched))]]))))
 
 (defn- without-tool-call [pending-diffs tool-call-id]
   (filterv #(not= tool-call-id (:tool-call-id %)) pending-diffs))
 
-(defn- resolve-diff-actions [state tool-call-id option-id]
-  (let [topic-id (topic-state/get-active-topic-id state)
-        existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])
-        resolved (topic-state/get-resolved-tool-calls state topic-id)]
-    [[:acp.effects/resolve-permission tool-call-id option-id]
-     [:effects/save
-      (topic-state/pending-diffs-path topic-id)
-      (without-tool-call existing tool-call-id)]
-     [:effects/save
-      (topic-state/resolved-tool-calls-path topic-id)
-      (conj resolved tool-call-id)]]))
+(defn- option-id-for-kind
+  "Find the :option-id of the entry in options whose :kind matches kind. nil if none."
+  [options kind]
+  (some #(when (= kind (:kind %)) (:option-id %)) options))
+
+(defn- resolve-diff-actions [state tool-call-id kind]
+  (let [topic-id    (topic-state/get-active-topic-id state)
+        existing    (or (get-in state (topic-state/pending-diffs-path topic-id)) [])
+        options-map (or (get-in state (topic-state/pending-permission-options-path topic-id)) {})
+        options     (get options-map tool-call-id)
+        option-id   (option-id-for-kind options kind)
+        cleanup     [[:effects/save
+                      (topic-state/pending-diffs-path topic-id)
+                      (without-tool-call existing tool-call-id)]
+                     [:effects/save
+                      (topic-state/pending-permission-options-path topic-id)
+                      (dissoc options-map tool-call-id)]
+                     [:effects/save
+                      (topic-state/resolved-tool-calls-path topic-id)
+                      (conj (topic-state/get-resolved-tool-calls state topic-id) tool-call-id)]]]
+    (if option-id
+      (into [[:acp.effects/resolve-permission tool-call-id option-id]] cleanup)
+      (do
+        (js/console.error "No option-id found for kind" kind "on tool-call" tool-call-id
+                          "— available options:" (pr-str options))
+        cleanup))))
 
 (defn accept-diff
-  "User accepted a proposed diff. Resolves the SDK's pending permission as
-   allow_once, drops matching entries from :pending-diffs, and records
-   tool-call-id in :resolved-tool-calls so any duplicate PostToolUse update
-   is suppressed by append-edit-diffs."
+  "User accepted a proposed diff. Looks up the option-id for ACP kind
+   \"allow_once\" from the stashed options, resolves the SDK's pending
+   permission with that option-id, clears the pending-diffs/options entries,
+   and records tool-call-id in :resolved-tool-calls so any duplicate
+   PostToolUse update is suppressed by append-edit-diffs."
   [state tool-call-id]
   (resolve-diff-actions state tool-call-id "allow_once"))
 
 (defn reject-diff
-  "User rejected a proposed diff. Resolves the SDK's pending permission as
-   reject_once, drops matching entries from :pending-diffs, and records
-   tool-call-id in :resolved-tool-calls."
+  "User rejected a proposed diff. Looks up the option-id for ACP kind
+   \"reject_once\" from the stashed options, resolves the SDK's pending
+   permission with that option-id, clears the pending-diffs/options entries,
+   and records tool-call-id in :resolved-tool-calls."
   [state tool-call-id]
   (resolve-diff-actions state tool-call-id "reject_once"))
 

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -65,6 +65,49 @@
         existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])]
     [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing diffs)]]))
 
+(defn append-pending-permission
+  "Add the diffs from an enriched ACP permission request to the active topic's
+   pending-diffs, tagging each with :tool-call-id so accept/reject can resolve
+   the right pending Promise. Returns nil when the permission carries no diffs."
+  [state enriched]
+  (let [{:keys [tool-call-id content]} (:tool-call enriched)
+        diffs (when content (filterv #(= "diff" (:type %)) content))]
+    (when (seq diffs)
+      (let [topic-id (topic-state/get-active-topic-id state)
+            existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])
+            tagged   (mapv #(assoc % :tool-call-id tool-call-id) diffs)]
+        [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing tagged)]]))))
+
+(defn- without-tool-call [pending-diffs tool-call-id]
+  (filterv #(not= tool-call-id (:tool-call-id %)) pending-diffs))
+
+(defn- resolve-diff-actions [state tool-call-id option-id]
+  (let [topic-id (topic-state/get-active-topic-id state)
+        existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])
+        resolved (topic-state/get-resolved-tool-calls state topic-id)]
+    [[:acp.effects/resolve-permission tool-call-id option-id]
+     [:effects/save
+      (topic-state/pending-diffs-path topic-id)
+      (without-tool-call existing tool-call-id)]
+     [:effects/save
+      (topic-state/resolved-tool-calls-path topic-id)
+      (conj resolved tool-call-id)]]))
+
+(defn accept-diff
+  "User accepted a proposed diff. Resolves the SDK's pending permission as
+   allow_once, drops matching entries from :pending-diffs, and records
+   tool-call-id in :resolved-tool-calls so any duplicate PostToolUse update
+   is suppressed by append-edit-diffs."
+  [state tool-call-id]
+  (resolve-diff-actions state tool-call-id "allow_once"))
+
+(defn reject-diff
+  "User rejected a proposed diff. Resolves the SDK's pending permission as
+   reject_once, drops matching entries from :pending-diffs, and records
+   tool-call-id in :resolved-tool-calls."
+  [state tool-call-id]
+  (resolve-diff-actions state tool-call-id "reject_once"))
+
 (defn set-active
   "Set the active topic and initialize its ACP session."
   [_state topic-id]

--- a/src/gremllm/renderer/actions/topic.cljs
+++ b/src/gremllm/renderer/actions/topic.cljs
@@ -60,7 +60,7 @@
    [:topic.effects/auto-save topic-id]])
 
 (defn append-pending-diffs [state diffs]
-  ;; TODO: incoming diffs should be matched with acp-session-id
+  ;; TODO (inbound-routing): see state/topic.cljs acp-session-id-path
   (let [topic-id (topic-state/get-active-topic-id state)
         existing (or (get-in state (topic-state/pending-diffs-path topic-id)) [])]
     [[:effects/save (topic-state/pending-diffs-path topic-id) (into existing diffs)]]))
@@ -72,6 +72,7 @@
    :pending-permission-options keyed by :tool-call-id (so accept/reject can
    map ACP :kind to the agent-defined :option-id). No-op when no diffs."
   [state enriched]
+  ;; TODO (inbound-routing): see state/topic.cljs acp-session-id-path
   (let [{:keys [tool-call-id content]} (:tool-call enriched)
         diffs (when content (filterv #(= "diff" (:type %)) content))]
     (when (seq diffs)

--- a/src/gremllm/renderer/core.cljs
+++ b/src/gremllm/renderer/core.cljs
@@ -49,6 +49,15 @@
                          (fn [_ event-data]
                            (nxr/dispatch store {} [[:acp.events/session-update (acp-codec/acp-session-update-from-ipc event-data)]])))
 
+    ;; Handle ACP permission-pending events from main process. The payload is
+    ;; an already-coerced AcpPermissionRequest (passed via send-to-renderer
+    ;; which clj->js-es the map; we reverse the trip back to CLJS here).
+    (.onAcpPermissionPending js/window.electronAPI
+                             (fn [_ event-data]
+                               (nxr/dispatch store {}
+                                             [[:topic.actions/append-pending-permission
+                                               (js->clj event-data :keywordize-keys true)]])))
+
     ;; Render on every change
     (add-watch store ::render-topic
                (fn [_ _ _ state]

--- a/src/gremllm/renderer/state/topic.cljs
+++ b/src/gremllm/renderer/state/topic.cljs
@@ -42,6 +42,15 @@
   [state topic-id]
   (or (get-in state (resolved-tool-calls-path topic-id)) #{}))
 
+(defn pending-permission-options-path [topic-id]
+  (-> topics-path (conj topic-id :session :pending-permission-options)))
+
+(defn get-pending-permission-options
+  "Return the options vector the agent sent with the pending permission
+   for tool-call-id, or nil if no entry is stashed."
+  [state topic-id tool-call-id]
+  (get-in state (conj (pending-permission-options-path topic-id) tool-call-id)))
+
 (defn excerpts-path [topic-id]
   (conj (topic-path topic-id) :excerpts))
 

--- a/src/gremllm/renderer/state/topic.cljs
+++ b/src/gremllm/renderer/state/topic.cljs
@@ -61,8 +61,21 @@
   (get-in (get-topic state topic-id) [:session :id]))
 
 (defn acp-session-id-path [topic-id]
-  ;; TODO: add reverse lookup from acp-session-id to topic-id for correct
-  ;; inbound routing of session updates to the originating topic
+  ;; TODO (inbound-routing): renderer ACP inbound handlers dispatch to the
+  ;; active topic, not to the topic whose agent emitted the event. Cross-turn
+  ;; topic switches land session updates, pending diffs, and pending
+  ;; permissions on the wrong topic.
+  ;;
+  ;; Fix: reverse lookup from acp-session-id to topic-id, resolved at the IPC
+  ;; boundary in renderer/core.cljs before per-domain actions dispatch.
+  ;;
+  ;; Affected: actions/topic.cljs append-pending-diffs and
+  ;; append-pending-permission; core.cljs onAcpSessionUpdate.
+  ;;
+  ;; Click-time accept/reject is defended by construction: Accept/Reject
+  ;; buttons render only on the topic owning :pending-diffs, so click-time
+  ;; and append-time active-topic always match. The gap is purely at IPC
+  ;; arrival.
   (-> topics-path (conj topic-id :session :id)))
 
 (defn find-message-index-by-tool-call-id

--- a/src/gremllm/renderer/state/topic.cljs
+++ b/src/gremllm/renderer/state/topic.cljs
@@ -34,6 +34,14 @@
 (defn pending-diffs-path [topic-id]
   (-> topics-path (conj topic-id :session :pending-diffs)))
 
+(defn resolved-tool-calls-path [topic-id]
+  (-> topics-path (conj topic-id :session :resolved-tool-calls)))
+
+(defn get-resolved-tool-calls
+  "Return the set of resolved tool-call-ids for topic-id, or empty set."
+  [state topic-id]
+  (or (get-in state (resolved-tool-calls-path topic-id)) #{}))
+
 (defn excerpts-path [topic-id]
   (conj (topic-path topic-id) :excerpts))
 

--- a/src/gremllm/renderer/ui/document.cljs
+++ b/src/gremllm/renderer/ui/document.cljs
@@ -6,19 +6,17 @@
 
 (defn- render-diff-segments [segments]
   (into [:div]
-        (mapv (fn [{:keys [type content old-text new-text]}]
+        (mapv (fn [{:keys [type content old-text new-text tool-call-id]}]
                 (case type
                   :text       [:span content]
                   :diff-block [:div.diff-block
                                [:del old-text]
                                [:ins new-text]
                                [:div.diff-controls
-                                [:button {:on {:click [[:topic.actions/accept-diff
-                                                        {:old-text old-text :new-text new-text}]]}}
+                                [:button {:on {:click [[:topic.actions/accept-diff tool-call-id]]}}
                                  "Accept"]
                                 [:button {:class "secondary outline"
-                                          :on {:click [[:topic.actions/reject-diff
-                                                        {:old-text old-text :new-text new-text}]]}}
+                                          :on {:click [[:topic.actions/reject-diff tool-call-id]]}}
                                  "Reject"]]]))
               segments)))
 

--- a/src/gremllm/renderer/ui/document/diffs.cljs
+++ b/src/gremllm/renderer/ui/document/diffs.cljs
@@ -155,7 +155,13 @@
         (if (< pos (count content))
           (conj segments {:type :text :content (subs content pos)})
           segments)
-        (let [{:keys [char-index length old-text new-text anchor-status]} (first diffs)]
+        (let [group (first diffs)
+              {:keys [char-index length old-text new-text anchor-status]} group
+              ;; tool-call-id lives on the original diff entries (group's :diffs).
+              ;; Merged overlapping diffs come from the same tool-call by
+              ;; construction (Edit emits one diff per call), so picking the
+              ;; first is correct.
+              tool-call-id (-> group :diffs first :tool-call-id)]
           (recur (max pos (+ char-index length))
                  (rest diffs)
                  (cond-> segments
@@ -163,7 +169,11 @@
                    (conj {:type :text :content (subs content pos char-index)})
 
                    true
-                   (conj {:type :diff-block :old-text old-text :new-text new-text :anchor-status anchor-status}))))))))
+                   (conj {:type         :diff-block
+                          :old-text     old-text
+                          :new-text     new-text
+                          :tool-call-id tool-call-id
+                          :anchor-status anchor-status}))))))))
 
 (defn compose
   "Unified diff composition pipeline. Produces separate :diff-block segments for

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -170,6 +170,15 @@
 
 (def AcpSession
   "Session state produced by an ACP agent for a topic."
+  ;; TODO: runtime [:session] also carries two transient keys not declared here:
+  ;;   :resolved-tool-calls         #{tool-call-id ...}
+  ;;   :pending-permission-options  {tool-call-id [AcpPermissionOption ...]}
+  ;; Written by renderer.actions.topic/append-pending-permission and
+  ;; resolve-diff-actions. Omitted because mt/strip-extra-keys-transformer in
+  ;; codec/topic-for-disk doubles as the disk allowlist — declaring them here
+  ;; would start persisting them. Fix is a split: PersistedAcpSession (current
+  ;; shape, disk) + in-memory AcpSession that mu/merges the transients,
+  ;; mirroring PersistedTopic/Topic.
   [:map
    ;; TODO: id should be required
    [:id {:optional true}         :string]

--- a/src/gremllm/schema/codec/acp.cljs
+++ b/src/gremllm/schema/codec/acp.cljs
@@ -74,6 +74,17 @@
     (let [diffs (filterv #(= "diff" (:type %)) content)]
       (when (seq diffs) diffs))))
 
+(defn permission-edit-diffs
+  "Extracts diff items from an Edit/Write permission request's :tool-call :content.
+   Returns a vector of diff maps or nil when none present.
+   Distinct from edit-diffs (PostToolUse path): permission requests arrive
+   pre-write so the renderer can render a proposal before approval."
+  [permission-request]
+  (let [content (get-in permission-request [:tool-call :content])]
+    (when (seq content)
+      (let [diffs (filterv #(= "diff" (:type %)) content)]
+        (when (seq diffs) diffs)))))
+
 (defn read-event?
   "True when a tool-call-update is a Read response event (any payload)."
   [{:keys [session-update] :as update}]
@@ -294,12 +305,15 @@
    acp.permission/enrich-permission-params (see that ns for the registry
    pattern and Zed references).
    Consumer: acp-permission/resolve-permission reads :kind, :tool-name (on
-   \"fetch\"), and (on \"edit\") :raw-input.:path / :raw-input.:file-path."
+   \"fetch\"), and (on \"edit\") :raw-input.:path / :raw-input.:file-path.
+   :content carries diff items on edit permission requests (Claude Agent SDK
+   includes them so the client can render a proposal before approval)."
   [:map
    [:tool-call-id              :string]
    [:kind                      AcpToolKind]
    [:tool-name {:optional true} :string]
-   [:raw-input {:optional true} AcpPermissionRawInput]])
+   [:raw-input {:optional true} AcpPermissionRawInput]
+   [:content   {:optional true} [:maybe [:vector AcpToolCallContentItem]]]])
 
 (def AcpPermissionRequest
   "ACP requestPermission params shape."

--- a/src/gremllm/schema/codec/acp/permission.cljs
+++ b/src/gremllm/schema/codec/acp/permission.cljs
@@ -63,39 +63,49 @@
 
 (defn resolve-permission
   "Determine permission outcome from a coerced AcpPermissionRequest and session cwd.
-   Returns {:outcome {:outcome \"selected\" :option-id \"...\"}}
-   or      {:outcome {:outcome \"cancelled\"}}."
+
+   Returns a tagged result:
+     {:resolution :immediate
+      :outcome    {:outcome \"selected\" :option-id \"...\"}}   ; or :outcome \"cancelled\"
+     {:resolution :deferred
+      :tool-call-id \"tc\"
+      :diffs        [{:type \"diff\" :path ... :old-text ... :new-text ...}]}
+
+   :deferred is returned for in-workspace edits — the caller is responsible
+   for stashing a resolver keyed by :tool-call-id and surfacing :diffs to the
+   user for accept/reject. All other paths (read, fetch, out-of-workspace
+   edit, unhandled kinds) return :immediate with a synchronous outcome."
   [permission-request session-cwd]
   (let [{:keys [options tool-call]} permission-request
-        {:keys [kind]} tool-call]
+        {:keys [kind tool-call-id]} tool-call]
     ;; Policy (not transport validation): an empty options list means the agent
     ;; offered nothing actionable, so cancel rather than fabricate a selection.
     (if (empty? options)
-      {:outcome {:outcome "cancelled"}}
+      {:resolution :immediate
+       :outcome    {:outcome "cancelled"}}
       (case kind
         "read"
         (let [opt (select-option options ["allow_always" "allow_once"] first)]
-          {:outcome {:outcome "selected" :option-id (:option-id opt)}})
+          {:resolution :immediate
+           :outcome    {:outcome "selected" :option-id (:option-id opt)}})
 
         "edit"
-        ;; Critical workflow nuance: approving an in-workspace edit/write means
-        ;; "allow the agent to complete the proposal path", not "write the file
-        ;; immediately". The ACP bridge keeps writeTextFile as a dry-run no-op,
-        ;; so the successful path is still non-mutating. Rejecting changes the
-        ;; semantics entirely: Claude reports that the user refused the tool, and
-        ;; the proposal step fails instead of returning a reviewable diff.
-        ;; Prefer allow_once so every Edit re-enters this resolver and gets a
-        ;; fresh path check. allow_always would create a session-scoped rule
-        ;; keyed only on toolName, bypassing the workspace-root guard for all
-        ;; subsequent edits—including ones outside the workspace root.
+        ;; In-workspace edit defers to the user via the pending-diffs UI.
+        ;; Out-of-workspace edit auto-rejects immediately (preserves the
+        ;; workspace-root guard from the prior policy).
         (let [raw-path       (requested-path tool-call)
               normalized-cwd (when session-cwd (.resolve path-module session-cwd))
               normalized-req (when raw-path (.resolve path-module raw-path))]
           (if (and normalized-cwd normalized-req (within-root? normalized-req normalized-cwd))
-            (let [opt (select-option options ["allow_once" "allow_always"] first)]
-              {:outcome {:outcome "selected" :option-id (:option-id opt)}})
+            {:resolution    :deferred
+             :tool-call-id  tool-call-id
+             :diffs         (let [content (:content tool-call)
+                                  diffs   (when content
+                                            (filterv #(= "diff" (:type %)) content))]
+                              (when (seq diffs) diffs))}
             (let [opt (select-option options ["reject_once" "reject_always"] last)]
-              {:outcome {:outcome "selected" :option-id (:option-id opt)}})))
+              {:resolution :immediate
+               :outcome    {:outcome "selected" :option-id (:option-id opt)}})))
 
         "fetch"
         ;; WebSearch is read-only and idempotent; mirror the "read" policy
@@ -104,10 +114,13 @@
         ;; route those to a renderer-side permission dialog.
         (if (= "WebSearch" (requested-tool-name tool-call))
           (let [opt (select-option options ["allow_always" "allow_once"] first)]
-            {:outcome {:outcome "selected" :option-id (:option-id opt)}})
+            {:resolution :immediate
+             :outcome    {:outcome "selected" :option-id (:option-id opt)}})
           (let [opt (select-option options ["reject_once" "reject_always"] last)]
-            {:outcome {:outcome "selected" :option-id (:option-id opt)}}))
+            {:resolution :immediate
+             :outcome    {:outcome "selected" :option-id (:option-id opt)}}))
 
         ;; Default: no policy defined for this kind yet — reject until classified.
         (let [opt (select-option options ["reject_once" "reject_always"] last)]
-          {:outcome {:outcome "selected" :option-id (:option-id opt)}})))))
+          {:resolution :immediate
+           :outcome    {:outcome "selected" :option-id (:option-id opt)}})))))

--- a/src/js/acp/README.md
+++ b/src/js/acp/README.md
@@ -15,7 +15,7 @@ SDK client and the in-process agent over ndjson streams.
 ## Division Of Responsibility
 
 - `src/js/acp/index.js`: stream bridge, `ClientSideConnection`,
-  `AgentSideConnection`, session cwd tracking, dry-run `writeTextFile`
+  `AgentSideConnection`, session cwd tracking
 - `src/gremllm/main/effects/acp.cljs`: initialization, handshake, permission
   resolution, file-read callback wiring, session update dispatch, prompt and
   session APIs
@@ -23,12 +23,13 @@ SDK client and the in-process agent over ndjson streams.
   invoked by `main.effects.acp`; keeps workspace-path checks and approval
   logic out of the JS transport bridge
 
-## Dry-Run Write Behavior
+## File Writes
 
-`writeTextFile` intentionally acknowledges writes without mutating disk. That
-keeps the agent on the proposal path so it can return a reviewable diff, while
-Gremllm remains in control of whether changes are later accepted or rejected
-through its own workflow.
+Gremllm does not implement the ACP `writeTextFile` client method and advertises
+`fs.writeTextFile: false` in its capabilities. The agent's MCP `Edit`/`Write`
+tools write directly through Claude Code's internal filesystem path after
+permission is granted; gating happens at the permission layer (deferred
+approval via `requestPermission`), not the write layer.
 
 ## Entry Points
 

--- a/src/js/acp/index.js
+++ b/src/js/acp/index.js
@@ -44,17 +44,6 @@ function createConnection(options = {}) {
     },
     async readTextFile(params) {
       return callbacks.onReadTextFile(params);
-    },
-    // Intentional dry-run: acknowledge ACP writes so the agent can complete the
-    // tool call successfully and surface a reviewable diff/proposal, but never
-    // mutate disk here. Gremllm applies file changes later through its own
-    // explicit accept/reject flow. If permission is rejected instead, Claude
-    // interprets the step as a user denial and reports the tool call as failed.
-    async writeTextFile(params) {
-      if (callbacks.onWriteTextFile) {
-        callbacks.onWriteTextFile(params);
-      }
-      return {};
     }
   };
 

--- a/test/gremllm/main/effects/acp_integration_test.cljs
+++ b/test/gremllm/main/effects/acp_integration_test.cljs
@@ -2,6 +2,7 @@
   (:require ["fs/promises" :as fsp]
             ["os" :as os]
             ["path" :as path]
+            [clojure.string :as str]
             [cljs.test :refer [deftest is testing async]]
             [gremllm.main.actions]
             [gremllm.main.actions.acp :as acp-actions]
@@ -23,23 +24,25 @@
       (delegate params))))
 
 (defn- live-acp-context
-  [{:keys [copy-doc?]}]
+  [{:keys [copy-doc? on-pending-permission]}]
   (let [tmp-dir  (path/join (.tmpdir os) (str "gremllm-test-" (random-uuid)))
         src-path (path/resolve "resources/gremllm-launch-log.md")]
-    {:store    (atom {})
-     :recorder (acp-trace/make-recorder)
-     :tmp-dir  tmp-dir
-     :src-path src-path
-     :doc-path (when copy-doc?
-                 (path/join tmp-dir "gremllm-launch-log.md"))}))
+    {:store                 (atom {})
+     :recorder              (acp-trace/make-recorder)
+     :tmp-dir               tmp-dir
+     :src-path              src-path
+     :doc-path              (when copy-doc?
+                              (path/join tmp-dir "gremllm-launch-log.md"))
+     :on-pending-permission on-pending-permission}))
 
 (defn- initialize-recorded-acp!
-  [{:keys [store recorder]}]
+  [{:keys [store recorder on-pending-permission]}]
   (with-redefs [acp/read-text-file (make-read-recorder (:on-read recorder))]
     (acp/initialize
-      {:on-session-update (acp/make-session-update-callback store (:on-session-update recorder))
-       :on-permission     (:on-permission recorder)
-       :on-write          (:on-write recorder)})))
+      {:on-session-update     (acp/make-session-update-callback store (:on-session-update recorder))
+       :on-permission         (:on-permission recorder)
+       :on-write              (:on-write recorder)
+       :on-pending-permission on-pending-permission})))
 
 (defn- setup-live-acp!
   [{:keys [tmp-dir src-path doc-path] :as ctx}]
@@ -157,44 +160,110 @@
                                                       :prompt   "Summarize the first paragraph..."
                                                       :done     done}))))))))
 
-(defn- some-diff-event?
-  "True when the recorder captured at least one session update carrying diff content
-   (i.e. an :edit-completed? event consumable by the diff-staging pipeline)."
-  [events]
-  (some (fn [{:keys [kind payload]}]
-          (and (= :session-update kind)
-               (acp-codec/edit-completed? (:update payload))))
-        events))
+(defn- pick-option-id
+  "Find the option-id whose :kind matches the given kind in an enriched
+   permission request's :options vector. Mirrors renderer's option-id-for-kind."
+  [enriched kind]
+  (->> (:options enriched)
+       (some (fn [opt] (when (= kind (:kind opt)) (:option-id opt))))))
 
-(deftest test-live-document-first-edit
-  (testing "document-first edit: trace all coerced events, observe (not assert) writeTextFile"
+(defn- make-decider
+  "Build an :on-pending-permission callback that captures each enriched request
+   into the given atom, then resolves it with the option-id matching decision-kind.
+
+   The resolve must be deferred: acp/initialize fires on-pending-permission
+   *before* stash-pending-permission! registers the resolver (same synchronous
+   block), so synchronous resolution would no-op and hang the SDK forever."
+  [decision-kind captured]
+  (fn [enriched]
+    (swap! captured conj enriched)
+    (let [tool-call-id (get-in enriched [:tool-call :tool-call-id])
+          option-id    (pick-option-id enriched decision-kind)]
+      (when option-id
+        (js/setTimeout
+          #(acp/resolve-pending-permission! tool-call-id option-id)
+          0)))))
+
+(def ^:private edit-prompt
+  "Read the linked document. Do not plan or ask questions; just make one edit now: change the title to anything. Do not change anything else.")
+
+(deftest test-live-edit-accept
+  (testing "domain workflow: agent requests Edit, user accepts, fs write occurs"
     (async done
-      (let [ctx    (live-acp-context {:copy-doc? true})
-            result (atom nil)]
+      (let [captured (atom [])
+            ctx      (live-acp-context {:copy-doc?             true
+                                        :on-pending-permission (make-decider "allow_once" captured)})
+            result   (atom nil)]
         (-> (setup-live-acp! ctx)
             (.then (fn [_] (acp/new-session (:tmp-dir ctx))))
             (.then (fn [session-id]
                      (acp/prompt session-id
                        (acp-actions/prompt-content-blocks
-                         {:text "Read the linked document. Do not plan or ask questions; just make one edit now: change the title to anything. Do not change anything else."}
+                         {:text edit-prompt}
                          (:doc-path ctx)))))
             (.then (fn [^js r]
                      (reset! result r)
                      (is (= "end_turn" (.-stopReason r)))
-                     (is (some-diff-event? @(-> ctx :recorder :events))
-                         "Expected at least one session update with diff content (edit-completed?). The agent must propose file mutations via a diff-emitting channel; until the follow-up to commit 322fc41 lands this assertion is the red guide-rail.")
-                     (print-event-summary! "document-first-edit" (:recorder ctx) [:write])
+                     (let [edit-perms (->> @captured
+                                           (filter #(= "edit" (get-in % [:tool-call :kind]))))
+                           edit-perm  (first edit-perms)
+                           diffs      (->> (get-in edit-perm [:tool-call :content])
+                                           (filter #(= "diff" (:type %))))
+                           opt-kinds  (set (map :kind (:options edit-perm)))]
+                       (is (seq edit-perms)
+                           "Expected at least one pending-permission for an edit tool call")
+                       (is (seq diffs)
+                           "Expected diff content in the captured edit permission")
+                       (is (every? #(str/starts-with? (:path %) (:tmp-dir ctx)) diffs)
+                           "Expected every diff path to be inside the test tmp-dir")
+                       (is (contains? opt-kinds "allow_once")
+                           "Expected allow_once option in the permission request")
+                       (is (contains? opt-kinds "reject_once")
+                           "Expected reject_once option in the permission request"))
+                     (print-event-summary! "edit-accept" (:recorder ctx) [:permission :write])
                      (println "=== end ===")
-                     ;; disallowedTools blocks Edit/Write/MultiEdit/NotebookEdit but not Bash;
-                     ;; comparing on-disk content to the source copy also catches Bash-based circumvention.
+                     (js/Promise.all #js [(.readFile fsp (:src-path ctx) "utf8")
+                                          (.readFile fsp (:doc-path ctx) "utf8")])))
+            (.then (fn [^js contents]
+                     (is (not= (aget contents 0) (aget contents 1))
+                         "Expected document.md on disk to differ from source after accept.")))
+            (.catch (fn [err]
+                      (is false (str "edit-accept test failed: " err))))
+            (.finally (fn []
+                        (finish-live-acp! ctx result {:scenario "edit-accept"
+                                                      :prompt   edit-prompt
+                                                      :done     done}))))))))
+
+(deftest test-live-edit-reject
+  (testing "domain workflow: agent requests Edit, user rejects, fs write suppressed"
+    (async done
+      (let [captured (atom [])
+            ctx      (live-acp-context {:copy-doc?             true
+                                        :on-pending-permission (make-decider "reject_once" captured)})
+            result   (atom nil)]
+        (-> (setup-live-acp! ctx)
+            (.then (fn [_] (acp/new-session (:tmp-dir ctx))))
+            (.then (fn [session-id]
+                     (acp/prompt session-id
+                       (acp-actions/prompt-content-blocks
+                         {:text edit-prompt}
+                         (:doc-path ctx)))))
+            (.then (fn [^js r]
+                     (reset! result r)
+                     (is (some #(= "edit" (get-in % [:tool-call :kind])) @captured)
+                         "Expected at least one pending-permission for an edit tool call (subsumes the dropped guide-rail).")
+                     (print-event-summary! "edit-reject" (:recorder ctx) [:permission :write])
+                     (println "=== end ===")
+                     ;; disallowedTools blocks MultiEdit/NotebookEdit; this comparison
+                     ;; also catches Bash-based circumvention.
                      (js/Promise.all #js [(.readFile fsp (:src-path ctx) "utf8")
                                           (.readFile fsp (:doc-path ctx) "utf8")])))
             (.then (fn [^js contents]
                      (is (= (aget contents 0) (aget contents 1))
-                         "Expected document.md on disk to be unchanged from the source copy.")))
+                         "Expected document.md on disk to be unchanged after reject.")))
             (.catch (fn [err]
-                      (is false (str "document-first-edit test failed: " err))))
+                      (is false (str "edit-reject test failed: " err))))
             (.finally (fn []
-                        (finish-live-acp! ctx result {:scenario "document-first-edit"
-                                                      :prompt   "...change the title to anything..."
+                        (finish-live-acp! ctx result {:scenario "edit-reject"
+                                                      :prompt   edit-prompt
                                                       :done     done}))))))))

--- a/test/gremllm/main/effects/acp_integration_test.cljs
+++ b/test/gremllm/main/effects/acp_integration_test.cljs
@@ -169,20 +169,16 @@
 
 (defn- make-decider
   "Build an :on-pending-permission callback that captures each enriched request
-   into the given atom, then resolves it with the option-id matching decision-kind.
-
-   The resolve must be deferred: acp/initialize fires on-pending-permission
-   *before* stash-pending-permission! registers the resolver (same synchronous
-   block), so synchronous resolution would no-op and hang the SDK forever."
+   into the given atom, then synchronously resolves it with the option-id matching
+   decision-kind. acp/initialize stashes the resolver before firing this callback,
+   so synchronous resolution is safe."
   [decision-kind captured]
   (fn [enriched]
     (swap! captured conj enriched)
     (let [tool-call-id (get-in enriched [:tool-call :tool-call-id])
           option-id    (pick-option-id enriched decision-kind)]
       (when option-id
-        (js/setTimeout
-          #(acp/resolve-pending-permission! tool-call-id option-id)
-          0)))))
+        (acp/resolve-pending-permission! tool-call-id option-id)))))
 
 (def ^:private edit-prompt
   "Read the linked document. Do not plan or ask questions; just make one edit now: change the title to anything. Do not change anything else.")

--- a/test/gremllm/main/effects/acp_integration_test.cljs
+++ b/test/gremllm/main/effects/acp_integration_test.cljs
@@ -157,37 +157,6 @@
                                                       :prompt   "Summarize the first paragraph..."
                                                       :done     done}))))))))
 
-(deftest test-live-write-new-file
-  (testing "write-new-file prompt: observe whether Write tool triggers writeTextFile"
-    (async done
-      (let [ctx    (live-acp-context nil)
-            result (atom nil)]
-        (-> (setup-live-acp! ctx)
-            (.then (fn [_] (acp/new-session (:tmp-dir ctx))))
-            (.then (fn [session-id]
-                     (acp/prompt session-id
-                       [{:type "text"
-                         :text "Create a new file called notes.md in the current directory with the single line: hello"}])))
-            (.then (fn [^js r]
-                     (reset! result r)
-                     (is (= "end_turn" (.-stopReason r)))
-                     (is (pos? (count @(-> ctx :recorder :events))) "Expected at least one event")
-                     (print-event-summary! "write-new-file" (:recorder ctx) [:write :permission])
-                     (let [notes-path (path/join (:tmp-dir ctx) "notes.md")]
-                       (println (str "  notes.md on disk: "
-                                     (try
-                                       (.accessSync (js/require "fs") notes-path)
-                                       "YES — SDK wrote directly"
-                                       (catch :default _
-                                         "NO — dry-run prevented write")))))
-                     (println "=== end ===")))
-            (.catch (fn [err]
-                      (is false (str "write-new-file test failed: " err))))
-            (.finally (fn []
-                        (finish-live-acp! ctx result {:scenario "write-new-file"
-                                                      :prompt   "Create a new file called notes.md..."
-                                                      :done     done}))))))))
-
 (defn- some-diff-event?
   "True when the recorder captured at least one session update carrying diff content
    (i.e. an :edit-completed? event consumable by the diff-staging pipeline)."

--- a/test/gremllm/main/effects/acp_integration_test.cljs
+++ b/test/gremllm/main/effects/acp_integration_test.cljs
@@ -41,7 +41,6 @@
     (acp/initialize
       {:on-session-update     (acp/make-session-update-callback store (:on-session-update recorder))
        :on-permission         (:on-permission recorder)
-       :on-write              (:on-write recorder)
        :on-pending-permission on-pending-permission})))
 
 (defn- setup-live-acp!
@@ -151,7 +150,7 @@
                      (reset! result r)
                      (is (= "end_turn" (.-stopReason r)))
                      (is (pos? (count @(-> ctx :recorder :events))) "Expected at least one event")
-                     (print-event-summary! "read-only" (:recorder ctx) [:read :write :permission])
+                     (print-event-summary! "read-only" (:recorder ctx) [:read :permission])
                      (println "=== end ===")))
             (.catch (fn [err]
                       (is false (str "read-only test failed: " err))))
@@ -216,7 +215,7 @@
                            "Expected allow_once option in the permission request")
                        (is (contains? opt-kinds "reject_once")
                            "Expected reject_once option in the permission request"))
-                     (print-event-summary! "edit-accept" (:recorder ctx) [:permission :write])
+                     (print-event-summary! "edit-accept" (:recorder ctx) [:permission])
                      (println "=== end ===")
                      (js/Promise.all #js [(.readFile fsp (:src-path ctx) "utf8")
                                           (.readFile fsp (:doc-path ctx) "utf8")])))
@@ -248,7 +247,7 @@
                      (reset! result r)
                      (is (some #(= "edit" (get-in % [:tool-call :kind])) @captured)
                          "Expected at least one pending-permission for an edit tool call (subsumes the dropped guide-rail).")
-                     (print-event-summary! "edit-reject" (:recorder ctx) [:permission :write])
+                     (print-event-summary! "edit-reject" (:recorder ctx) [:permission])
                      (println "=== end ===")
                      ;; disallowedTools blocks MultiEdit/NotebookEdit; this comparison
                      ;; also catches Bash-based circumvention.

--- a/test/gremllm/main/effects/acp_test.cljs
+++ b/test/gremllm/main/effects/acp_test.cljs
@@ -307,6 +307,52 @@
                              (.finally (fn [] (done)))))))
               (.catch (fn [e] (js/console.error "unexpected error" e) (done)))))))))
 
+(deftest test-resolve-cb-returns-promise-for-deferred
+  (testing "in-workspace edit: resolve-cb returns a Promise that resolves when registry fires"
+    (async done
+      (let [pending-events  (atom [])
+            captured-cb     (atom nil)
+            {:keys [result]} (make-fake-env)
+            path-mod        (js/require "path")
+            cwd             (.resolve path-mod (.cwd js/process) "resources")
+            file            (.resolve path-mod cwd "gremllm-launch-log.md")
+            raw-params      #js {:sessionId "s-1"
+                                 :toolCall  #js {:toolCallId "tc-defer"
+                                                 :kind       "edit"
+                                                 :title      "Edit"
+                                                 :rawInput   #js {:file_path file}
+                                                 :content    #js [#js {:type "diff"
+                                                                       :path file
+                                                                       :oldText "a"
+                                                                       :newText "b"}]
+                                                 :locations  #js []}
+                                 :options   #js [#js {:optionId "allow-once"
+                                                      :kind     "allow_once"
+                                                      :name     "Allow"}
+                                                 #js {:optionId "reject-once"
+                                                      :kind     "reject_once"
+                                                      :name     "Reject"}]}]
+        (with-redefs [acp/create-connection
+                      (fn [^js opts]
+                        (reset! captured-cb (.-resolvePermission opts))
+                        result)]
+          (-> (acp/initialize
+                {:on-session-update     (fn [_] nil)
+                 :on-pending-permission (fn [enriched]
+                                          (swap! pending-events conj enriched))})
+              (.then
+                (fn [_]
+                  (let [result-promise (@captured-cb raw-params cwd)]
+                    (is (instance? js/Promise result-promise))
+                    (is (= 1 (count @pending-events)) "tap should fire once with enriched request")
+                    (is (= "tc-defer" (-> @pending-events first :tool-call :tool-call-id)))
+                    (acp/resolve-pending-permission! "tc-defer" "allow-once")
+                    (-> result-promise
+                        (.then (fn [^js js-out]
+                                 (is (= "selected"   (.. js-out -outcome -outcome)))
+                                 (is (= "allow-once" (.. ^js js-out -outcome -optionId)))))
+                        (.finally (fn [] (.then (acp/shutdown) (fn [_] (done)))))))))))))))
+
 (deftest test-pending-permission-registry
   (testing "stash/resolve registers a resolver keyed by tool-call-id and fires it once"
     (let [fired (atom nil)]

--- a/test/gremllm/main/effects/acp_test.cljs
+++ b/test/gremllm/main/effects/acp_test.cljs
@@ -306,3 +306,23 @@
                                           "dispose should have settled before shutdown promise resolves")))
                              (.finally (fn [] (done)))))))
               (.catch (fn [e] (js/console.error "unexpected error" e) (done)))))))))
+
+(deftest test-pending-permission-registry
+  (testing "stash/resolve registers a resolver keyed by tool-call-id and fires it once"
+    (let [fired (atom nil)]
+      (acp/stash-pending-permission! "tc-A" #(reset! fired %))
+      (is (some? (acp/pending-permission-snapshot)))
+      (acp/resolve-pending-permission! "tc-A" "allow_once")
+      (is (= "allow_once" @fired))
+      (is (nil? (get (acp/pending-permission-snapshot) "tc-A"))
+          "resolver should be removed after firing")))
+  (testing "resolve with unknown id is a no-op (logged elsewhere)"
+    (is (nil? (acp/resolve-pending-permission! "tc-unknown" "allow_once"))))
+  (testing "stash replaces an existing resolver with the same id and logs"
+    (let [a (atom :a-unfired)
+          b (atom :b-unfired)]
+      (acp/stash-pending-permission! "tc-dup" #(reset! a %))
+      (acp/stash-pending-permission! "tc-dup" #(reset! b %))
+      (acp/resolve-pending-permission! "tc-dup" "reject_once")
+      (is (= :a-unfired @a) "first resolver should not fire")
+      (is (= "reject_once" @b) "second resolver should fire"))))

--- a/test/gremllm/main/effects/acp_test.cljs
+++ b/test/gremllm/main/effects/acp_test.cljs
@@ -148,8 +148,11 @@
               (.then (fn [_] (initialize-dev (fn [_] nil))))
               (.then (fn [_]
                        (is (= 1 @create-count))
+                       (acp/stash-pending-permission! "tc-lifecycle" (fn [_] nil))
                        (acp/shutdown)
                        (is (= 1 (:dispose-count @calls)))
+                       (is (= {} (acp/pending-permission-snapshot))
+                           "shutdown should clear stashed permission resolvers")
                        (is (thrown-with-msg? js/Error #"ACP not initialized"
                              (acp/new-session "/tmp/ws")))))
               (.finally (fn []

--- a/test/gremllm/main/effects/acp_trace.cljs
+++ b/test/gremllm/main/effects/acp_trace.cljs
@@ -17,12 +17,11 @@
 
 (defn make-recorder
   "Create a new event recorder.
-   Returns {:events atom :on-session-update fn :on-permission fn :on-write fn :on-read fn}.
+   Returns {:events atom :on-session-update fn :on-permission fn :on-read fn}.
 
    Wire the taps into acp/initialize:
      (acp/make-session-update-callback store (:on-session-update r))  -> on-session-update arg
      (:on-permission r)                                                -> on-permission arg
-     (:on-write r)                                                     -> on-write arg
      (:on-read r)                                                      -> on-read arg"
   []
   (let [start  (js/performance.now)
@@ -34,9 +33,6 @@
      :on-permission
      (fn [coerced]
        (swap! events conj {:ts (- (js/performance.now) start) :kind :permission :payload coerced}))
-     :on-write
-     (fn [params]
-       (swap! events conj {:ts (- (js/performance.now) start) :kind :write :payload params}))
      :on-read
      (fn [params]
        (swap! events conj {:ts (- (js/performance.now) start) :kind :read :payload params}))}))

--- a/test/gremllm/main/effects/acp_trace_test.cljs
+++ b/test/gremllm/main/effects/acp_trace_test.cljs
@@ -7,23 +7,21 @@
             [gremllm.main.effects.acp-trace :as acp-trace]))
 
 (deftest test-make-recorder-shape
-  (testing "returns an events atom and four tap functions"
-    (let [{:keys [events on-session-update on-permission on-write on-read]} (acp-trace/make-recorder)]
+  (testing "returns an events atom and three tap functions"
+    (let [{:keys [events on-session-update on-permission on-read]} (acp-trace/make-recorder)]
       (is (= cljs.core/Atom (type events)))
       (is (fn? on-session-update))
       (is (fn? on-permission))
-      (is (fn? on-write))
       (is (fn? on-read)))))
 
 (deftest test-events-accumulate-in-order
-  (testing "all four taps append to the same atom in arrival order"
-    (let [{:keys [events on-session-update on-permission on-write on-read]} (acp-trace/make-recorder)]
+  (testing "all three taps append to the same atom in arrival order"
+    (let [{:keys [events on-session-update on-permission on-read]} (acp-trace/make-recorder)]
       (on-session-update {:session-update :agent-message-chunk :acp-session-id "s1"})
       (on-read {:path "/doc.md" :line nil :limit nil})
-      (on-write {:path "/doc.md" :session-id "s1" :content-length 10})
       (on-permission {:acp-session-id "s1" :tool-call {:tool-call-id "tc1"}})
-      (is (= 4 (count @events)))
-      (is (= [:session-update :read :write :permission] (map :kind @events)))
+      (is (= 3 (count @events)))
+      (is (= [:session-update :read :permission] (map :kind @events)))
       (is (every? number? (map :ts @events))))))
 
 (deftest test-write-trace-creates-file

--- a/test/gremllm/renderer/actions/acp_test.cljs
+++ b/test/gremllm/renderer/actions/acp_test.cljs
@@ -231,3 +231,27 @@
           (js-delete js/globalThis "window")
           (aset js/globalThis "window" old-window))))))
 
+(deftest append-edit-diffs-suppression-test
+  (testing "skips diffs whose tool-call-id is already in :resolved-tool-calls"
+    (let [topic-id "t1"
+          state    {:active-topic-id topic-id
+                    :topics {topic-id {:id topic-id
+                                       :session {:pending-diffs []
+                                                 :resolved-tool-calls #{"tc-1"}}}}}
+          update   {:session-update :tool-call-update
+                    :tool-call-id   "tc-1"
+                    :content        [{:type "diff" :path "/p" :old-text "a" :new-text "b"}]}]
+      (is (nil? (acp/append-edit-diffs state update))
+          "PostToolUse for already-resolved tool-call should be ignored")))
+  (testing "passes through diffs for unresolved tool-call-id (existing path)"
+    (let [topic-id "t1"
+          state    {:active-topic-id topic-id
+                    :topics {topic-id {:id topic-id
+                                       :session {:pending-diffs []
+                                                 :resolved-tool-calls #{}}}}}
+          update   {:session-update :tool-call-update
+                    :tool-call-id   "tc-2"
+                    :content        [{:type "diff" :path "/p" :old-text "a" :new-text "b"}]}
+          actions  (acp/append-edit-diffs state update)]
+      (is (= 1 (count actions)))
+      (is (= :topic.actions/append-pending-diffs (ffirst actions))))))

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -117,3 +117,59 @@
             [:topic.effects/auto-save topic-id]]
            (topic/finalize-turn {} topic-id)))))
 
+(deftest append-pending-permission-test
+  (testing "appends diffs tagged with tool-call-id to the active topic's pending-diffs"
+    (let [topic-id "t1"
+          state    {:active-topic-id topic-id
+                    :topics {topic-id {:id topic-id
+                                       :session {:pending-diffs []}}}}
+          enriched {:tool-call {:tool-call-id "tc-1"
+                                :content [{:type "diff" :path "/p" :old-text "a" :new-text "b"}]}}
+          actions  (topic/append-pending-permission state enriched)]
+      (is (= [[:effects/save
+               (topic-state/pending-diffs-path topic-id)
+               [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}]]]
+             actions))))
+  (testing "is a no-op when permission carries no diff content"
+    (let [state    {:active-topic-id "t1"
+                    :topics {"t1" {:id "t1" :session {:pending-diffs []}}}}
+          enriched {:tool-call {:tool-call-id "tc-1" :content []}}]
+      (is (nil? (topic/append-pending-permission state enriched))))))
+
+(deftest accept-diff-test
+  (testing "emits IPC resolve, removes matching diffs, and records tool-call-id as resolved"
+    (let [topic-id "t1"
+          state    {:active-topic-id topic-id
+                    :topics {topic-id {:id topic-id
+                                       :session {:pending-diffs
+                                                 [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}
+                                                  {:type "diff" :path "/q" :old-text "x" :new-text "y" :tool-call-id "tc-2"}]
+                                                 :resolved-tool-calls #{}}}}}
+          actions  (topic/accept-diff state "tc-1")]
+      (is (= [[:acp.effects/resolve-permission "tc-1" "allow_once"]
+              [:effects/save
+               (topic-state/pending-diffs-path topic-id)
+               [{:type "diff" :path "/q" :old-text "x" :new-text "y" :tool-call-id "tc-2"}]]
+              [:effects/save
+               (topic-state/resolved-tool-calls-path topic-id)
+               #{"tc-1"}]]
+             actions)))))
+
+(deftest reject-diff-test
+  (testing "emits IPC reject, removes matching diffs, and records tool-call-id as resolved"
+    (let [topic-id "t1"
+          state    {:active-topic-id topic-id
+                    :topics {topic-id {:id topic-id
+                                       :session {:pending-diffs
+                                                 [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}]
+                                                 :resolved-tool-calls #{"tc-prev"}}}}}
+          actions  (topic/reject-diff state "tc-1")]
+      (is (= [[:acp.effects/resolve-permission "tc-1" "reject_once"]
+              [:effects/save
+               (topic-state/pending-diffs-path topic-id)
+               []]
+              [:effects/save
+               (topic-state/resolved-tool-calls-path topic-id)
+               #{"tc-prev" "tc-1"}]]
+             actions)))))
+

--- a/test/gremllm/renderer/actions/topic_test.cljs
+++ b/test/gremllm/renderer/actions/topic_test.cljs
@@ -117,59 +117,105 @@
             [:topic.effects/auto-save topic-id]]
            (topic/finalize-turn {} topic-id)))))
 
+(def ^:private sample-options
+  [{:kind "allow_always" :option-id "allow_always" :name "Always Allow"}
+   {:kind "allow_once"   :option-id "allow"        :name "Allow"}
+   {:kind "reject_once"  :option-id "reject"       :name "Reject"}])
+
 (deftest append-pending-permission-test
-  (testing "appends diffs tagged with tool-call-id to the active topic's pending-diffs"
+  (testing "appends diffs tagged with tool-call-id and stashes options keyed by tool-call-id"
     (let [topic-id "t1"
           state    {:active-topic-id topic-id
                     :topics {topic-id {:id topic-id
                                        :session {:pending-diffs []}}}}
           enriched {:tool-call {:tool-call-id "tc-1"
-                                :content [{:type "diff" :path "/p" :old-text "a" :new-text "b"}]}}
+                                :content [{:type "diff" :path "/p" :old-text "a" :new-text "b"}]}
+                    :options sample-options}
           actions  (topic/append-pending-permission state enriched)]
       (is (= [[:effects/save
                (topic-state/pending-diffs-path topic-id)
-               [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}]]]
+               [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}]]
+              [:effects/save
+               (topic-state/pending-permission-options-path topic-id)
+               {"tc-1" sample-options}]]
              actions))))
+  (testing "preserves existing pending-permission-options when a second permission lands"
+    (let [topic-id "t1"
+          existing-options [{:kind "allow_once" :option-id "ok" :name "ok"}]
+          state    {:active-topic-id topic-id
+                    :topics {topic-id {:id topic-id
+                                       :session {:pending-diffs []
+                                                 :pending-permission-options {"tc-prev" existing-options}}}}}
+          enriched {:tool-call {:tool-call-id "tc-1"
+                                :content [{:type "diff" :path "/p" :old-text "a" :new-text "b"}]}
+                    :options sample-options}
+          actions  (topic/append-pending-permission state enriched)]
+      (is (= {"tc-prev" existing-options "tc-1" sample-options}
+             (nth (second actions) 2)))))
   (testing "is a no-op when permission carries no diff content"
     (let [state    {:active-topic-id "t1"
                     :topics {"t1" {:id "t1" :session {:pending-diffs []}}}}
-          enriched {:tool-call {:tool-call-id "tc-1" :content []}}]
+          enriched {:tool-call {:tool-call-id "tc-1" :content []}
+                    :options sample-options}]
       (is (nil? (topic/append-pending-permission state enriched))))))
 
 (deftest accept-diff-test
-  (testing "emits IPC resolve, removes matching diffs, and records tool-call-id as resolved"
+  (testing "looks up allow_once option-id, emits IPC resolve, clears pending-diffs/options, records resolved"
     (let [topic-id "t1"
           state    {:active-topic-id topic-id
                     :topics {topic-id {:id topic-id
                                        :session {:pending-diffs
                                                  [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}
                                                   {:type "diff" :path "/q" :old-text "x" :new-text "y" :tool-call-id "tc-2"}]
+                                                 :pending-permission-options {"tc-1" sample-options
+                                                                              "tc-2" sample-options}
                                                  :resolved-tool-calls #{}}}}}
           actions  (topic/accept-diff state "tc-1")]
-      (is (= [[:acp.effects/resolve-permission "tc-1" "allow_once"]
+      (is (= [[:acp.effects/resolve-permission "tc-1" "allow"]
               [:effects/save
                (topic-state/pending-diffs-path topic-id)
                [{:type "diff" :path "/q" :old-text "x" :new-text "y" :tool-call-id "tc-2"}]]
+              [:effects/save
+               (topic-state/pending-permission-options-path topic-id)
+               {"tc-2" sample-options}]
               [:effects/save
                (topic-state/resolved-tool-calls-path topic-id)
                #{"tc-1"}]]
              actions)))))
 
 (deftest reject-diff-test
-  (testing "emits IPC reject, removes matching diffs, and records tool-call-id as resolved"
+  (testing "looks up reject_once option-id, emits IPC reject, clears pending-diffs/options, records resolved"
     (let [topic-id "t1"
           state    {:active-topic-id topic-id
                     :topics {topic-id {:id topic-id
                                        :session {:pending-diffs
                                                  [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}]
+                                                 :pending-permission-options {"tc-1" sample-options}
                                                  :resolved-tool-calls #{"tc-prev"}}}}}
           actions  (topic/reject-diff state "tc-1")]
-      (is (= [[:acp.effects/resolve-permission "tc-1" "reject_once"]
+      (is (= [[:acp.effects/resolve-permission "tc-1" "reject"]
               [:effects/save
                (topic-state/pending-diffs-path topic-id)
                []]
+              [:effects/save
+               (topic-state/pending-permission-options-path topic-id)
+               {}]
               [:effects/save
                (topic-state/resolved-tool-calls-path topic-id)
                #{"tc-prev" "tc-1"}]]
              actions)))))
 
+(deftest resolve-diff-missing-kind-test
+  (testing "logs and emits no resolve effect when stashed options omit the requested kind"
+    (with-console-error-silenced
+      (let [topic-id "t1"
+            options-without-allow [{:kind "reject_once" :option-id "reject" :name "Reject"}]
+            state    {:active-topic-id topic-id
+                      :topics {topic-id {:id topic-id
+                                         :session {:pending-diffs
+                                                   [{:type "diff" :path "/p" :old-text "a" :new-text "b" :tool-call-id "tc-1"}]
+                                                   :pending-permission-options {"tc-1" options-without-allow}
+                                                   :resolved-tool-calls #{}}}}}
+            actions  (topic/accept-diff state "tc-1")]
+        (is (not-any? #(= :acp.effects/resolve-permission (first %)) actions)
+            "no resolve-permission effect when kind not found")))))

--- a/test/gremllm/schema/codec/acp/permission_test.cljs
+++ b/test/gremllm/schema/codec/acp/permission_test.cljs
@@ -73,65 +73,83 @@
         file-in-cwd  (.resolve path-mod cwd "gremllm-launch-log.md")
         file-out     (.resolve path-mod (.cwd js/process) "README.md")
         options      (full-options-js)
-        option-id    (fn [result] (get-in result [:outcome :option-id]))
-        make-req     (fn [kind tool-name raw-input]
+        immediate-id (fn [result]
+                       (when (= :immediate (:resolution result))
+                         (get-in result [:outcome :option-id])))
+        make-req     (fn [kind tool-name raw-input & [extra]]
                        (coerce-permission-req
-                         #js {:sessionId "session-known"
-                              :toolCall  #js {:toolCallId "tc"
-                                              :toolName   tool-name
-                                              :kind       kind
-                                              :title      "op"
-                                              :rawInput   raw-input
-                                              :locations  #js []}
-                              :options   options}))]
-    (testing "read tool call is allowed regardless of path"
+                         (clj->js
+                           {:sessionId "session-known"
+                            :toolCall  (merge {:toolCallId "tc"
+                                               :toolName   tool-name
+                                               :kind       kind
+                                               :title      "op"
+                                               :rawInput   raw-input
+                                               :locations  []}
+                                              (or extra {}))
+                            :options   (js->clj options)})))]
+    (testing "read tool call is :immediate allow"
       (is (= "allow-always"
-             (option-id (acp-permission/resolve-permission
-                          (make-req "read" "mcp__acp__Read" #js {:path file-in-cwd})
-                          cwd)))))
-    (testing "edit within cwd is allowed"
-      (is (= "allow-once"
-             (option-id (acp-permission/resolve-permission
-                          (make-req "edit" "mcp__acp__Edit" #js {:path file-in-cwd})
-                          cwd)))))
-    (testing "edit outside cwd is rejected"
+             (immediate-id (acp-permission/resolve-permission
+                             (make-req "read" "mcp__acp__Read" {:path file-in-cwd})
+                             cwd)))))
+    (testing "edit within cwd is :deferred carrying tool-call-id and diffs"
+      (let [result (acp-permission/resolve-permission
+                     (make-req "edit" "mcp__acp__Edit"
+                               {:file_path file-in-cwd}
+                               {:content [{:type "diff"
+                                           :path file-in-cwd
+                                           :oldText "a"
+                                           :newText "b"}]})
+                     cwd)]
+        (is (= :deferred (:resolution result)))
+        (is (= "tc" (:tool-call-id result)))
+        (is (= [{:type "diff" :path file-in-cwd :old-text "a" :new-text "b"}]
+               (:diffs result)))))
+    (testing "edit within cwd with no content still :deferred (empty diffs)"
+      (let [result (acp-permission/resolve-permission
+                     (make-req "edit" "mcp__acp__Edit" {:file_path file-in-cwd})
+                     cwd)]
+        (is (= :deferred (:resolution result)))
+        (is (nil? (:diffs result)))))
+    (testing "edit outside cwd is :immediate reject"
       (is (= "reject-once"
-             (option-id (acp-permission/resolve-permission
-                          (make-req "edit" "mcp__acp__Edit" #js {:file_path file-out})
-                          cwd)))))
-    (testing "edit without path metadata is rejected"
+             (immediate-id (acp-permission/resolve-permission
+                             (make-req "edit" "mcp__acp__Edit" {:file_path file-out})
+                             cwd)))))
+    (testing "edit without path metadata is :immediate reject"
       (is (= "reject-once"
-             (option-id (acp-permission/resolve-permission
-                          (make-req "edit" "mcp__acp__Edit" #js {:replace_all false})
-                          cwd)))))
-    (testing "edit with nil session-cwd is rejected"
+             (immediate-id (acp-permission/resolve-permission
+                             (make-req "edit" "mcp__acp__Edit" {:replace_all false})
+                             cwd)))))
+    (testing "edit with nil session-cwd is :immediate reject"
       (is (= "reject-once"
-             (option-id (acp-permission/resolve-permission
-                          (make-req "edit" "mcp__acp__Edit" #js {:path file-in-cwd})
-                          nil)))))
-    (testing "WebSearch fetch tool call is allowed"
+             (immediate-id (acp-permission/resolve-permission
+                             (make-req "edit" "mcp__acp__Edit" {:path file-in-cwd})
+                             nil)))))
+    (testing "WebSearch fetch tool call is :immediate allow"
       (is (= "allow-always"
-             (option-id (acp-permission/resolve-permission
-                          (make-req "fetch" "WebSearch" #js {:query "latest news"})
-                          cwd)))))
-    (testing "WebFetch fetch tool call is rejected (round-2 contract)"
+             (immediate-id (acp-permission/resolve-permission
+                             (make-req "fetch" "WebSearch" {:query "latest news"})
+                             cwd)))))
+    (testing "WebFetch fetch tool call is :immediate reject"
       (is (= "reject-once"
-             (option-id (acp-permission/resolve-permission
-                          (make-req "fetch" "WebFetch" #js {:url "https://example.com"})
-                          cwd)))))
-    (testing "empty options yields cancelled"
-      (is (= "cancelled"
-             (get-in (acp-permission/resolve-permission
-                       (coerce-permission-req
-                         #js {:sessionId "session-known"
-                              :toolCall  #js {:toolCallId "tc"
-                                              :kind       "read"
-                                              :title      "op"
-                                              :rawInput   #js {:path file-in-cwd}
-                                              :locations  #js []}
-                              :options   #js []})
-                       cwd)
-                     [:outcome :outcome]))))))
+             (immediate-id (acp-permission/resolve-permission
+                             (make-req "fetch" "WebFetch" {:url "https://example.com"})
+                             cwd)))))
+    (testing "empty options yields :immediate cancelled"
+      (let [result (acp-permission/resolve-permission
+                     (coerce-permission-req
+                       #js {:sessionId "session-known"
+                            :toolCall  #js {:toolCallId "tc"
+                                            :kind       "read"
+                                            :title      "op"
+                                            :rawInput   #js {:path file-in-cwd}
+                                            :locations  #js []}
+                            :options   #js []})
+                     cwd)]
+        (is (= :immediate (:resolution result)))
+        (is (= "cancelled" (get-in result [:outcome :outcome])))))))
 
 (deftest test-permission-request-fetch-kind-no-locations
   (testing "coerces requestPermission with fetch kind and absent locations"

--- a/test/gremllm/schema/codec/acp_test.cljs
+++ b/test/gremllm/schema/codec/acp_test.cljs
@@ -256,3 +256,33 @@
                 {:session-update :tool-call-update
                  :tool-call-id "toolu_01Ext"
                  :meta {:claude-code {:tool-name "Read"}}})))))
+
+(deftest test-permission-request-content-coercion
+  (testing "requestPermission payload with diff content coerces into :tool-call :content"
+    (let [coerced (acp-codec/acp-permission-request-from-js
+                    #js {:sessionId "s-1"
+                         :toolCall  #js {:toolCallId "tc-1"
+                                         :kind       "edit"
+                                         :rawInput   #js {:file_path "/ws/document.md"}
+                                         :content    #js [#js {:type "diff"
+                                                                :path "/ws/document.md"
+                                                                :oldText "old"
+                                                                :newText "new"}]}
+                         :options   #js []})
+          content (get-in coerced [:tool-call :content])]
+      (is (= 1 (count content)))
+      (is (= "diff" (-> content first :type)))
+      (is (= "old"  (-> content first :old-text)))
+      (is (= "new"  (-> content first :new-text)))
+      (is (= "/ws/document.md" (-> content first :path))))))
+
+(deftest test-permission-edit-diffs
+  (testing "returns diff items from a permission request's tool-call content"
+    (let [req {:tool-call {:content [{:type "diff" :path "/p" :old-text "a" :new-text "b"}
+                                      {:type "content" :text "ignored"}]}}]
+      (is (= [{:type "diff" :path "/p" :old-text "a" :new-text "b"}]
+             (acp-codec/permission-edit-diffs req)))))
+  (testing "returns nil when no diff items present"
+    (is (nil? (acp-codec/permission-edit-diffs {:tool-call {:content []}}))))
+  (testing "returns nil when content key absent"
+    (is (nil? (acp-codec/permission-edit-diffs {:tool-call {}})))))


### PR DESCRIPTION
- Replace `disallowedTools` write gating with a deferred permission layer that suspends the ACP tool call until the user accepts or rejects the proposed diff
- Add pending-permission registry in main process; IPC channels + preload bridge let the renderer subscribe and resolve each request by option-id
- Accept/reject actions update topic state and track resolved tool-calls so PostToolUse diffs are suppressed for already-decided writes
- Schema now surfaces diff content on permission requests so the renderer can render the change before the user decides
- ⚠️  Implementation is tested and functional; known tech debt — a refactor PR follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)