### PR TITLE
fix(acp): unpack SDK native binary from asar for packaged app

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -4,7 +4,9 @@ const { FuseV1Options, FuseVersion } = require("@electron/fuses");
 module.exports = {
 	name: "Gremllm",
 	packagerConfig: {
-		asar: true,
+		asar: {
+			unpack: "**/node_modules/@anthropic-ai/claude-agent-sdk-*/**",
+		},
 	},
 	rebuildConfig: {},
 	makers: [

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -9,8 +9,7 @@
             [gremllm.main.state :as state]
             [gremllm.schema.codec :as codec]
             [nexus.registry :as nxr]
-            ["electron/main" :refer [app BrowserWindow ipcMain]]
-            ["path" :as path]))
+            ["electron/main" :refer [app BrowserWindow ipcMain]]))
 
 (defn register-domain-handlers
   "Register IPC handlers for core domain operations.
@@ -107,34 +106,15 @@
          (nxr/dispatch store {}
                        [[:acp.effects/resolve-permission tool-call-id option-id]]))))
 
-(defn- set-claude-executable-for-packaged-app!
-  "In a packaged app the ACP SDK's native binary lives in app.asar.unpacked,
-   but require.resolve returns an asar-virtual path that spawn can't execute.
-   Setting this env var makes the SDK skip its own resolution entirely."
-  []
-  (when (.-isPackaged app)
-    (let [binary (path/join (.-resourcesPath js/process)
-                            "app.asar.unpacked" "node_modules" "@anthropic-ai"
-                            (str "claude-agent-sdk-" (.-platform js/process) "-" (.-arch js/process))
-                            "claude")]
-      (set! (.. js/process -env -CLAUDE_CODE_EXECUTABLE) binary))))
-
-(defn- setup-system-resources [store]
+(defn- initialize-app [store]
   (register-domain-handlers store)
   (menu/create-menu store)
-  (set-claude-executable-for-packaged-app!)
-  ;; Initialize ACP in-process agent eagerly at launch.
-  ;; Session updates and permission-pending events both flow into Nexus actions
-  ;; that fan out to the renderer via IPC.
   (acp-effects/initialize
     {:on-session-update
      (acp-effects/make-session-update-callback store nil)
      :on-pending-permission
      (fn [enriched]
-       (nxr/dispatch store {} [[:acp.events/permission-pending enriched]]))}))
-
-(defn- initialize-app [store]
-  (setup-system-resources store)
+       (nxr/dispatch store {} [[:acp.events/permission-pending enriched]]))})
   (nxr/dispatch store {} [[:window.actions/create]]))
 
 (defn- handle-app-activate

--- a/src/gremllm/main/core.cljs
+++ b/src/gremllm/main/core.cljs
@@ -9,7 +9,8 @@
             [gremllm.main.state :as state]
             [gremllm.schema.codec :as codec]
             [nexus.registry :as nxr]
-            ["electron/main" :refer [app BrowserWindow ipcMain]]))
+            ["electron/main" :refer [app BrowserWindow ipcMain]]
+            ["path" :as path]))
 
 (defn register-domain-handlers
   "Register IPC handlers for core domain operations.
@@ -106,9 +107,22 @@
          (nxr/dispatch store {}
                        [[:acp.effects/resolve-permission tool-call-id option-id]]))))
 
+(defn- set-claude-executable-for-packaged-app!
+  "In a packaged app the ACP SDK's native binary lives in app.asar.unpacked,
+   but require.resolve returns an asar-virtual path that spawn can't execute.
+   Setting this env var makes the SDK skip its own resolution entirely."
+  []
+  (when (.-isPackaged app)
+    (let [binary (path/join (.-resourcesPath js/process)
+                            "app.asar.unpacked" "node_modules" "@anthropic-ai"
+                            (str "claude-agent-sdk-" (.-platform js/process) "-" (.-arch js/process))
+                            "claude")]
+      (set! (.. js/process -env -CLAUDE_CODE_EXECUTABLE) binary))))
+
 (defn- setup-system-resources [store]
   (register-domain-handlers store)
   (menu/create-menu store)
+  (set-claude-executable-for-packaged-app!)
   ;; Initialize ACP in-process agent eagerly at launch.
   ;; Session updates and permission-pending events both flow into Nexus actions
   ;; that fan out to the renderer via IPC.

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -6,7 +6,8 @@
             [gremllm.schema.codec.acp.permission :as acp-permission]
             [nexus.registry :as nxr]
             ["/js/acp/index" :as acp-factory]
-            ["fs/promises" :as fsp]))
+            ["fs/promises" :as fsp]
+            ["path" :as path]))
 
 ;; _meta.claudeCode.options overrides for the pinned claude-agent-acp session-setup path
 ;; (node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1095-1137).
@@ -137,6 +138,25 @@
                                (throw err))))
                   (throw err))))))
 
+(defn- get-electron-app []
+  (when (exists? js/require)
+    (try
+      (.-app (js/require "electron/main"))
+      (catch :default _ nil))))
+
+(defn- set-claude-executable-for-packaged-app!
+  "In a packaged app the ACP SDK's native binary lives in app.asar.unpacked,
+   but require.resolve returns an asar-virtual path that spawn can't execute.
+   Setting this env var makes the SDK skip its own resolution entirely."
+  []
+  (when-let [app (get-electron-app)]
+    (when (.-isPackaged app)
+      (let [binary (path/join (.-resourcesPath js/process)
+                              "app.asar.unpacked" "node_modules" "@anthropic-ai"
+                              (str "claude-agent-sdk-" (.-platform js/process) "-" (.-arch js/process))
+                              "claude")]
+        (set! (.. js/process -env -CLAUDE_CODE_EXECUTABLE) binary)))))
+
 (defn initialize
   "Initialize ACP connection eagerly. Idempotent.
    opts keys:
@@ -148,6 +168,7 @@
                             to resolve-pending-permission! from inside this callback (e.g.
                             from tests) resolves the SDK Promise correctly."
   [{:keys [on-session-update on-permission on-pending-permission]}]
+  (set-claude-executable-for-packaged-app!)
   (if-let [ready (:ready @state)]
     ready
     (let [;; Per-connection tool-name tracker. Seeded from session updates so

--- a/src/gremllm/main/effects/acp.cljs
+++ b/src/gremllm/main/effects/acp.cljs
@@ -151,11 +151,13 @@
   []
   (when-let [app (get-electron-app)]
     (when (.-isPackaged app)
-      (let [binary (path/join (.-resourcesPath js/process)
-                              "app.asar.unpacked" "node_modules" "@anthropic-ai"
-                              (str "claude-agent-sdk-" (.-platform js/process) "-" (.-arch js/process))
-                              "claude")]
-        (set! (.. js/process -env -CLAUDE_CODE_EXECUTABLE) binary)))))
+      (let [platform-specific-package (str "claude-agent-sdk-"
+                                         (.-platform js/process) "-"
+                                         (.-arch js/process))
+            unpacked-binary-path    (path/join (.-resourcesPath js/process)
+                                               "app.asar.unpacked" "node_modules" "@anthropic-ai"
+                                               platform-specific-package "claude")]
+        (set! (.. js/process -env -CLAUDE_CODE_EXECUTABLE) unpacked-binary-path)))))
 
 (defn initialize
   "Initialize ACP connection eagerly. Idempotent.


### PR DESCRIPTION
- Native ACP SDK binary was packed inside the asar archive, making it non-executable in a packaged DMG build
- Added \`unpackDir\` in forge.config.js to exclude the binary from asar so it can be executed at runtime
- Moved SDK executable path resolution from \`main/core.cljs\` into \`effects/acp.cljs\` (FCIS: effect setup belongs in the shell)
- Extracted named bindings in the packaged-app path setup for readability

Fixes #258 