### PR TITLE
docs(spec): excerpt-anchored sessions design

### DIFF
--- a/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
+++ b/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
@@ -69,6 +69,12 @@ When a document opens with existing sessions, the latest one (by last-modified t
 
 Sessions are resumable and open-ended, identical to today's topics. "Session" refers to the AI interaction context, not a time-bounded event. No lifecycle states (open/closed/archived) are introduced.
 
+### Anchor Versioning
+
+Anchors are scoped to the document version that existed when the session was created. When document content changes, prior anchors are archived as belonging to a previous version and are not displayed. The session data is preserved, not deleted.
+
+This eliminates anchor drift as a design problem — anchors never follow edits, so there is no ambiguity about whether a bar still points to the right text. The mechanics of versioning (how versions are identified, what triggers archival, how archived sessions surface) are deferred.
+
 ### Deletion
 
 Session deletion is not included in the initial version. Sessions accumulate. Deletion can be added later through a context menu or session management UI.
@@ -114,7 +120,7 @@ The spec bets everything on one navigation channel and removes the fallback in S
 
 The spec describes the happy path precisely and is silent on every degraded path. Specific cases that need answers:
 
-- **Anchor drift:** When anchored text is edited, moved, or deleted across document revisions, what does the user observe? A silently orphaned bar looks like a bug. A vanishing bar destroys discoverability. "Defer drift handling" is acceptable; "no defined user-visible behavior" is not.
+- **~~Anchor drift~~:** Resolved — anchors are scoped to a document version. When content changes, prior anchors are archived and not displayed (see Anchor Versioning). No drift occurs.
 - **Wrong auto-activation:** If the latest session belongs to a different work context (e.g., a colleague's prior session in a shared draft), AI output goes into the wrong conversation silently. Does auto-activation signal itself as automatic?
 - **No retrieval cue:** When a user returns after days and doesn't remember where in the document they were working, how do they find the right session without a list or search?
 
@@ -155,4 +161,4 @@ This is the point of no return for the old UI. By this stage the data model is p
 - Annotation density management (clustering, progressive disclosure)
 - Scrollbar minimap marks
 - Cross-session references or linking
-- Anchor drift handling (what happens when the document text under an anchor changes)
+- Anchor versioning mechanics (version identity, archival triggers, surfacing archived sessions) — the design choice is made (see Anchor Versioning); the implementation is deferred

--- a/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
+++ b/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
@@ -11,7 +11,7 @@ This works for early prototyping but breaks the document-first principle. Topics
 
 ## Goal
 
-Anchor AI conversations to the document text that motivated them. Rename "Topic" to "Session" to reflect the new mental model: a session is a conversation that began at a specific place in the document, stays visually tied to that place, and is discoverable by reading the document itself.
+Anchor AI conversations to the document text that motivated them. A session is a conversation that began at a specific place in the document, stays visually tied to that place, and is discoverable by reading the document itself.
 
 The document becomes the navigation surface. The topic list goes away.
 
@@ -35,8 +35,6 @@ During a conversation, the user can add more excerpts as context for subsequent 
 
 Sessions are always created from a text selection. There are no unanchored, free-floating sessions.
 
-For whole-document questions (not tied to a specific passage), a shortcut creates a document-scoped session (anchor type `:document`, no specific excerpt). This preserves one creation mental model — every session starts from a deliberate user action.
-
 When text is selected and a session is already active, the popover offers two actions: **"Start session"** (creates a new session anchored to this selection) and **"Add excerpt"** (adds the selection as conversation context to the current session). Both are always visible.
 
 ### Visual Markers
@@ -46,7 +44,6 @@ Sessions appear in the document as **colored vertical bars in the right margin**
 - Each session gets a distinct color from a small rotating palette.
 - The active session's bar is fully opaque; inactive bars are dimmed.
 - Clicking a bar switches the chat panel to that session.
-- Whole-document sessions have no margin bar (they are not tied to a visible excerpt range).
 
 Bars do not modify the document text or its rendering pipeline. They are an overlay layer.
 
@@ -62,23 +59,15 @@ No session list panel, search, or minimap is included in this version. These are
 
 The chat panel remains always-visible on the right. Clicking a margin bar switches which session the panel displays — same interaction as clicking a topic in today's list, just triggered from the document margin.
 
-The panel header shows session context: the anchor excerpt text (truncated) for excerpt-anchored sessions, or the document filename for whole-document sessions.
-
 ### Empty State and Document Open
 
-When a document opens with no existing sessions, one whole-document session is auto-created and activated. The user lands in a ready-to-chat state immediately.
+When a document opens with no existing sessions, the chat panel shows an empty state prompting the user to select text. No session is auto-created.
 
-When a document opens with existing sessions, the latest one (by modified timestamps) is auto-activated.
+When a document opens with existing sessions, the latest one (by last-modified timestamp) is auto-activated.
 
 ### Session Lifecycle
 
 Sessions are resumable and open-ended, identical to today's topics. "Session" refers to the AI interaction context, not a time-bounded event. No lifecycle states (open/closed/archived) are introduced.
-
-### Session Naming
-
-Sessions auto-name from a truncation of the user's first message (e.g., "How does this compare to..."). Whole-document sessions follow the same rule. Renaming is not included in the initial version.
-
-**Rationale:** The anchor excerpt is already visible via the margin bar and text highlight — repeating it as the session name is redundant. The user's first message captures intent ("why did they start this session?"), which is not otherwise visible in the document UI.
 
 ### Deletion
 
@@ -90,7 +79,7 @@ Session deletion is not included in the initial version. Sessions accumulate. De
 
 A Session is an AI conversation anchored to a specific place in a document.
 
-- **Anchor** — what this session is tied to. Either a specific document excerpt (with the full `DocumentExcerpt` locator data) or the document as a whole. Required, immutable after creation.
+- **Anchor** — the document excerpt this session is tied to (the full `DocumentExcerpt` locator data). Required, immutable after creation.
 - **Excerpts** — conversation excerpts added during the session, distinct from the anchor. Consumed after each turn, same as today.
 - **ACP session** — the underlying agent session (ID, pending diffs). Unchanged.
 - **Messages** — conversation history. Unchanged.
@@ -101,23 +90,21 @@ The anchor is a new concept. Everything else carries forward from Topic with a n
 
 The anchor records the user's intent: "I want to discuss *this specific text*." It stores the selected text and its document location (block refs, line spans) — the same `DocumentExcerpt` shape the app already uses, promoted from a conversation artifact to a session identity.
 
-For whole-document sessions, the anchor records that the session is document-scoped, with no specific excerpt.
-
 ## Backward Compatibility
 
 None required. This is a pre-release MVP. Existing persisted topic data can be discarded. No migration path is needed.
 
 ## Staged Delivery
 
-This work is divided into four stages. Each stage leaves the app fully functional. The sequence front-loads design learning and defers mechanical work and irreversible UI changes.
+This work is divided into three stages. Each stage leaves the app fully functional. The sequence front-loads design learning and defers irreversible UI changes.
 
 ### Stage 1: Anchor Model (backend, small)
 
-Add the anchor concept to the data model. A topic gains an `:anchor` field that records its spawning excerpt or document-level scope. Persistence stores and loads the new field.
+Add the anchor concept to the data model. A topic gains an `:anchor` field that records its spawning excerpt. Persistence stores and loads the new field.
 
 The app works identically — the anchor is stored but not yet used by any UI. The old topic list and creation flow remain.
 
-**Learns:** Does the anchor/excerpt distinction fit cleanly into the schema and persistence layer?
+**Learns:** Does the anchor fit cleanly into the schema and persistence layer?
 
 ### Stage 2: Margin Bar Rendering (frontend, additive)
 
@@ -127,20 +114,16 @@ Clicking a bar switches the active topic, same as clicking in the list today. Bo
 
 **Learns:** Do bars position correctly against real document content? Does the visual treatment work? How does click-to-switch feel? This is the riskiest unknown — test it while the old UI is still a fallback.
 
-### Stage 3: Domain Rename (full-stack, mechanical)
+### Stage 3: Navigation Overhaul (frontend, the commitment)
 
-Rename Topic → Session everywhere: schema, state paths, action keywords, IPC channels, persistence directory and filenames, preload API, UI text. Zero behavior change.
+Remove the topic list and nav overlay. Change the excerpt selection popover to offer "Start session" and "Add excerpt." Wire up the empty state.
 
-**Why now, not earlier:** By this point the team has lived with the code during Stages 1–2 and knows which files were touched and which patterns emerged. The rename won't collide with ongoing structural changes, and new UI code won't be written with old names only to be immediately renamed.
-
-### Stage 4: Navigation Overhaul (frontend, the commitment)
-
-Remove the topic list and nav overlay. Change the excerpt selection popover to offer "Start session" and "Add excerpt." Add whole-document session auto-creation on document open. Wire up empty states and chat panel header context.
-
-This is the point of no return for the old UI. By this stage the data model is proven (Stage 1), bars are validated (Stage 2), and vocabulary is clean (Stage 3).
+This is the point of no return for the old UI. By this stage the data model is proven (Stage 1) and bars are validated (Stage 2). The Topic → Session rename happens when it's natural — during this stage or after — not as a dedicated phase.
 
 ## Out of Scope
 
+- Whole-document sessions (anchor type `:document`) — select text to start any session
+- Session naming — the margin bar and excerpt highlight identify sessions visually
 - Session list panel, search, or minimap — additive if margin bars prove insufficient
 - Session deletion UI
 - Session rename UI

--- a/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
+++ b/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
@@ -94,6 +94,30 @@ The anchor records the user's intent: "I want to discuss *this specific text*." 
 
 None required. This is a pre-release MVP. Existing persisted topic data can be discarded. No migration path is needed.
 
+## Open Questions (Blocking)
+
+These must be investigated before Stage 3 removes the topic list fallback.
+
+### OQ1: Return intent — users come back to a document for different reasons
+
+The spec auto-activates the latest session and expects users to navigate by scanning margin bars. But return behavior splits at least three ways: continuing where you left off, surveying what's been done, and looking for a specific past conversation. The spec treats all three as the same. Which return intent is primary for our users, and does auto-activation serve or disrupt it?
+
+### OQ2: Single-channel navigation — margin bars are the only way in
+
+The spec bets everything on one navigation channel and removes the fallback in Stage 3. Three independent concerns converge here:
+
+- If users scan bars directly rather than reading document text to find them, bars are just an unlabeled, unsearchable list — possibly worse than what they replace.
+- At 25+ sessions on a long document, bars may become indistinguishable noise. The spec defers density management but defines no signal for when bars have failed and no criteria for reverting.
+- For non-visual users (screen readers, keyboard-only), the channel doesn't exist at all — sessions have no accessible name, no keyboard trigger for the creation popover, and no programmatic active-state signal (CSS opacity and Custom Highlights carry no accessibility tree exposure).
+
+### OQ3: Degraded states — what the user sees when the design's assumptions break
+
+The spec describes the happy path precisely and is silent on every degraded path. Specific cases that need answers:
+
+- **Anchor drift:** When anchored text is edited, moved, or deleted across document revisions, what does the user observe? A silently orphaned bar looks like a bug. A vanishing bar destroys discoverability. "Defer drift handling" is acceptable; "no defined user-visible behavior" is not.
+- **Wrong auto-activation:** If the latest session belongs to a different work context (e.g., a colleague's prior session in a shared draft), AI output goes into the wrong conversation silently. Does auto-activation signal itself as automatic?
+- **No retrieval cue:** When a user returns after days and doesn't remember where in the document they were working, how do they find the right session without a list or search?
+
 ## Staged Delivery
 
 This work is divided into three stages. Each stage leaves the app fully functional. The sequence front-loads design learning and defers irreversible UI changes.

--- a/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
+++ b/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
@@ -41,7 +41,7 @@ When text is selected and a session is already active, the popover offers two ac
 
 ### Visual Markers
 
-Sessions appear in the document as **colored vertical bars in the left margin**, positioned alongside the anchored excerpt text. Bars span the height of the excerpt's block range.
+Sessions appear in the document as **colored vertical bars in the right margin**, positioned alongside the anchored excerpt text. Bars span the height of the excerpt's block range. The right-side placement creates a left-to-right flow — document content → margin hints → chat panel — so bars sit adjacent to the session they activate.
 
 - Each session gets a distinct color from a small rotating palette.
 - The active session's bar is fully opaque; inactive bars are dimmed.
@@ -54,7 +54,7 @@ When a session is active, its anchor excerpt text receives a subtle highlight (t
 
 ### Navigation
 
-Margin bars are the sole navigation surface, replacing the topic list entirely. The left nav overlay, its toggle button, and all topic list UI (rename, delete, new topic button) are removed.
+Margin bars are the sole navigation surface, replacing the topic list entirely. The nav overlay, its toggle button, and all topic list UI (rename, delete, new topic button) are removed.
 
 No session list panel, search, or minimap is included in this version. These are additive features if margin bars prove insufficient for documents with many sessions.
 

--- a/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
+++ b/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
@@ -1,0 +1,151 @@
+# Excerpt-Anchored Sessions
+
+**Date:** 2026-05-25
+**Status:** Draft
+
+## Context
+
+Gremllm organizes AI conversations as "Topics" — a flat list in a nav overlay, disconnected from the document content. Users create a topic, optionally add excerpts, and chat. The topic list is the only navigation surface.
+
+This works for early prototyping but breaks the document-first principle. Topics float free of the document; finding a previous conversation means scanning a list of names. The connection between "I was working on this paragraph" and "I had an AI conversation about it" exists only in the user's memory.
+
+## Goal
+
+Anchor AI conversations to the document text that motivated them. Rename "Topic" to "Session" to reflect the new mental model: a session is a conversation that began at a specific place in the document, stays visually tied to that place, and is discoverable by reading the document itself.
+
+The document becomes the navigation surface. The topic list goes away.
+
+## Design Principles Applied
+
+- **Document-first, not chat-first** — sessions are subordinate to the document. You find them by reading the document, not by browsing a separate list.
+- **Simple by default** — one creation path (select text → start session), one navigation mechanism (margin bars), one anchor per session.
+- **Expert judgment is elevated** — the anchor records what the user chose to investigate, preserving the "why here?" signal as part of the session's identity.
+
+## Product Decisions
+
+### Anchoring Model
+
+Each session is anchored to exactly one excerpt — the text selection that spawned it. This is the session's visual anchor in the document. The relationship is 1:1: one session, one anchor point, one margin bar.
+
+During a conversation, the user can add more excerpts as context for subsequent turns. These conversation excerpts are distinct from the anchor — they inform the AI but do not create additional visual markers in the document.
+
+**Rationale:** Research across Google Docs, Figma, Notion, GitHub PRs, Hypothesis, and legal annotation tools shows universal 1:1 anchoring. Multi-anchor models create ambiguity ("which marker is the real one?") without solving the discoverability problem that motivated them. The "where's that session?" concern is better addressed by navigation tools than by multiplying anchors.
+
+### Session Creation
+
+Sessions are always created from a text selection. There are no unanchored, free-floating sessions.
+
+For whole-document questions (not tied to a specific passage), a shortcut creates a document-scoped session (anchor type `:document`, no specific excerpt). This preserves one creation mental model — every session starts from a deliberate user action.
+
+When text is selected and a session is already active, the popover offers two actions: **"Start session"** (creates a new session anchored to this selection) and **"Add excerpt"** (adds the selection as conversation context to the current session). Both are always visible.
+
+### Visual Markers
+
+Sessions appear in the document as **colored vertical bars in the left margin**, positioned alongside the anchored excerpt text. Bars span the height of the excerpt's block range.
+
+- Each session gets a distinct color from a small rotating palette.
+- The active session's bar is fully opaque; inactive bars are dimmed.
+- Clicking a bar switches the chat panel to that session.
+- Whole-document sessions have no margin bar (they are not tied to a visible excerpt range).
+
+Bars do not modify the document text or its rendering pipeline. They are an overlay layer.
+
+When a session is active, its anchor excerpt text receives a subtle highlight (the app already uses the CSS Custom Highlight API for excerpt highlighting). Inactive sessions show only the margin bar.
+
+### Navigation
+
+Margin bars are the sole navigation surface, replacing the topic list entirely. The left nav overlay, its toggle button, and all topic list UI (rename, delete, new topic button) are removed.
+
+No session list panel, search, or minimap is included in this version. These are additive features if margin bars prove insufficient for documents with many sessions.
+
+### Chat Panel Behavior
+
+The chat panel remains always-visible on the right. Clicking a margin bar switches which session the panel displays — same interaction as clicking a topic in today's list, just triggered from the document margin.
+
+The panel header shows session context: the anchor excerpt text (truncated) for excerpt-anchored sessions, or the document filename for whole-document sessions.
+
+### Empty State and Document Open
+
+When a document opens with no existing sessions, one whole-document session is auto-created and activated. The user lands in a ready-to-chat state immediately.
+
+When a document opens with existing sessions, the latest one (by modified timestamps) is auto-activated.
+
+### Session Lifecycle
+
+Sessions are resumable and open-ended, identical to today's topics. "Session" refers to the AI interaction context, not a time-bounded event. No lifecycle states (open/closed/archived) are introduced.
+
+### Session Naming
+
+Sessions auto-name from a truncation of the user's first message (e.g., "How does this compare to..."). Whole-document sessions follow the same rule. Renaming is not included in the initial version.
+
+**Rationale:** The anchor excerpt is already visible via the margin bar and text highlight — repeating it as the session name is redundant. The user's first message captures intent ("why did they start this session?"), which is not otherwise visible in the document UI.
+
+### Deletion
+
+Session deletion is not included in the initial version. Sessions accumulate. Deletion can be added later through a context menu or session management UI.
+
+## Domain Model
+
+### Session (replaces Topic)
+
+A Session is an AI conversation anchored to a specific place in a document.
+
+- **Anchor** — what this session is tied to. Either a specific document excerpt (with the full `DocumentExcerpt` locator data) or the document as a whole. Required, immutable after creation.
+- **Excerpts** — conversation excerpts added during the session, distinct from the anchor. Consumed after each turn, same as today.
+- **ACP session** — the underlying agent session (ID, pending diffs). Unchanged.
+- **Messages** — conversation history. Unchanged.
+
+The anchor is a new concept. Everything else carries forward from Topic with a name change.
+
+### What "Anchor" Captures
+
+The anchor records the user's intent: "I want to discuss *this specific text*." It stores the selected text and its document location (block refs, line spans) — the same `DocumentExcerpt` shape the app already uses, promoted from a conversation artifact to a session identity.
+
+For whole-document sessions, the anchor records that the session is document-scoped, with no specific excerpt.
+
+## Backward Compatibility
+
+None required. This is a pre-release MVP. Existing persisted topic data can be discarded. No migration path is needed.
+
+## Staged Delivery
+
+This work is divided into four stages. Each stage leaves the app fully functional. The sequence front-loads design learning and defers mechanical work and irreversible UI changes.
+
+### Stage 1: Anchor Model (backend, small)
+
+Add the anchor concept to the data model. A topic gains an `:anchor` field that records its spawning excerpt or document-level scope. Persistence stores and loads the new field.
+
+The app works identically — the anchor is stored but not yet used by any UI. The old topic list and creation flow remain.
+
+**Learns:** Does the anchor/excerpt distinction fit cleanly into the schema and persistence layer?
+
+### Stage 2: Margin Bar Rendering (frontend, additive)
+
+Render colored margin bars in the document panel for topics that have an excerpt anchor. The old topic list still works — bars are a new layer alongside the existing UI, not a replacement.
+
+Clicking a bar switches the active topic, same as clicking in the list today. Both navigation surfaces coexist.
+
+**Learns:** Do bars position correctly against real document content? Does the visual treatment work? How does click-to-switch feel? This is the riskiest unknown — test it while the old UI is still a fallback.
+
+### Stage 3: Domain Rename (full-stack, mechanical)
+
+Rename Topic → Session everywhere: schema, state paths, action keywords, IPC channels, persistence directory and filenames, preload API, UI text. Zero behavior change.
+
+**Why now, not earlier:** By this point the team has lived with the code during Stages 1–2 and knows which files were touched and which patterns emerged. The rename won't collide with ongoing structural changes, and new UI code won't be written with old names only to be immediately renamed.
+
+### Stage 4: Navigation Overhaul (frontend, the commitment)
+
+Remove the topic list and nav overlay. Change the excerpt selection popover to offer "Start session" and "Add excerpt." Add whole-document session auto-creation on document open. Wire up empty states and chat panel header context.
+
+This is the point of no return for the old UI. By this stage the data model is proven (Stage 1), bars are validated (Stage 2), and vocabulary is clean (Stage 3).
+
+## Out of Scope
+
+- Session list panel, search, or minimap — additive if margin bars prove insufficient
+- Session deletion UI
+- Session rename UI
+- Session lifecycle states (open/closed/archived)
+- Annotation density management (clustering, progressive disclosure)
+- Scrollbar minimap marks
+- Cross-session references or linking
+- Anchor drift handling (what happens when the document text under an anchor changes)

--- a/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
+++ b/docs/specs/2026-05-25-excerpt-anchored-sessions-design.md
@@ -124,6 +124,35 @@ The spec describes the happy path precisely and is silent on every degraded path
 - **Wrong auto-activation:** If the latest session belongs to a different work context (e.g., a colleague's prior session in a shared draft), AI output goes into the wrong conversation silently. Does auto-activation signal itself as automatic?
 - **No retrieval cue:** When a user returns after days and doesn't remember where in the document they were working, how do they find the right session without a list or search?
 
+## Design Bets
+
+These are the design's load-bearing assumptions — not problems to solve before shipping, but hypotheses to test with users after implementation. If any bet is wrong, the fix is structural, not incremental. Watch for disconfirming signal early.
+
+### Bet 1: AI sessions behave like annotations
+
+> "Research across Google Docs, Figma, Notion, GitHub PRs, Hypothesis, and legal annotation tools shows universal 1:1 anchoring."
+
+The 1:1 anchoring model and the cited evidence from annotation tools rest on a structural analogy: that AI conversation sessions are the same kind of artifact as comments or annotations. But annotations are reactive — a thought pinned to a fixed referent. AI sessions are exploratory, evolving, and routinely span multiple document regions. The analogy is doing enormous load-bearing work without examination. If AI sessions are a structurally different artifact class, the 1:1 model, the margin bar identity system, and the "no multi-anchor" decision all inherit a flawed premise.
+
+**Watch for:** Sessions that outgrow their anchor — conversations where the anchor text becomes irrelevant halfway through, or where users wish they could "move" a session to a different part of the document.
+
+### Bet 2: The atomic unit of "what I want to discuss" is a text region, not a conceptual thread
+
+> "Sessions are always created from a text selection."
+> "The anchor records the user's intent: 'I want to discuss this specific text.'"
+
+The spec treats the document as a collection of nodes — selectable passages — and anchors conversations to them. But knowledge work often follows arrows: a pricing assumption in paragraph 3 that constrains the risk assessment in paragraph 12 that undermines the thesis in the executive summary. The meaningful unit isn't a passage; it's the thread of reasoning connecting passages. A text selection captures a node. It can't capture "the tension between these two claims" or "the logic chain running through sections 2, 4, and 7." If the interesting conversations happen along arrows rather than at nodes, 1:1 anchoring to a text region systematically misses the conversations that carry the most expert signal.
+
+**Watch for:** Users who select text as a starting point but immediately paste or reference other document sections in their first message — a signal that the real unit of discussion is a cross-cutting thread, not a passage.
+
+### Bet 3: Users navigate past conversations by spatial document context, not by content recall
+
+> "The document becomes the navigation surface. The topic list goes away."
+
+The spec bets that users will remember AI conversations by where in the document they happened — spatial recall — rather than by what they were about — content recall. This is a cognitive model claim about how PE analysts actually think. If they search for "the pricing assumptions conversation" rather than "the one near paragraph 12," the document-as-navigation thesis is wrong regardless of how margin bars are implemented. Spatial recall works for small counts and recent sessions; content recall dominates as sessions accumulate and time passes.
+
+**Watch for:** Users scrolling through the document hunting for a margin bar they can't find, or asking "where was that conversation about X?" — both signals that content recall, not spatial recall, is the dominant retrieval mode.
+
 ## Staged Delivery
 
 This work is divided into three stages. Each stage leaves the app fully functional. The sequence front-loads design learning and defers irreversible UI changes.


### PR DESCRIPTION
- Adds design spec for replacing the floating topic list with sessions anchored to document text selections
- Each session is tied 1:1 to the excerpt that spawned it; margin bars in the right column make sessions discoverable by reading the document
- Documents product decisions: anchoring model, session creation flow, visual markers, session naming, anchor versioning, and anchor drift handling
- Includes open questions on navigation, return intent, and degraded states; design bets section with post-ship validation signals