### PR TITLE
refactor(schema): add Malli fn-schema annotations and enable instrumentation

### DIFF
--- a/dev/gremllm/renderer/dev.cljs
+++ b/dev/gremllm/renderer/dev.cljs
@@ -1,10 +1,15 @@
 (ns gremllm.renderer.dev
   "Development entry point for renderer. Adds dev tooling then delegates to core."
   (:require [gremllm.renderer.core :as core]
+            [malli.dev.cljs :as malli-dev]
             [nexus.action-log :as action-log]
             [dataspex.core :as dataspex]))
 
 (defn ^:export main []
+  ;; Enforce :malli/schema hints on creation-point fns while developing, so the
+  ;; shapes documented at those fns can't silently drift. Renderer-only: this
+  ;; checker only wraps fns that execute in this (browser) runtime.
+  (malli-dev/start!)
   (action-log/inspect)
   ;; connect to our JVM Dataspex server for remote viewing at http://localhost:7117/
   (dataspex/connect-remote-inspector)

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -22,14 +22,17 @@
   :test {:target :node-test
          :output-to "target/test.js"
          :ns-regexp "(?<!integration)-test$"
+         :devtools {:preloads [gremllm.test-setup]}
          :autorun true}
 
   :test-all {:target :node-test
              :output-to "target/test-all.js"
              :ns-regexp "(test|integration-test)$"
+             :devtools {:preloads [gremllm.test-setup]}
              :autorun true}
 
   :test-integration {:target :node-test
                      :output-to "target/test-integration.js"
                      :ns-regexp "-integration-test$"
+                     :devtools {:preloads [gremllm.test-setup]}
                      :autorun true}}}

--- a/src/gremllm/renderer/actions/excerpt.cljs
+++ b/src/gremllm/renderer/actions/excerpt.cljs
@@ -6,7 +6,7 @@
 (defn capture->excerpt
   "Pure transform: ephemeral capture + locator-hints -> durable DocumentExcerpt.
    `id` is supplied by the caller so UUID generation stays outside this helper."
-  {:malli/schema [:=> [:cat schema/CapturedSelection :any :string] schema/DocumentExcerpt]}
+  {:malli/schema [:=> [:cat [:map [:text :string]] :any :string] schema/DocumentExcerpt]}
   [captured locator-hints id]
   {:id id
    :text (:text captured)

--- a/src/gremllm/renderer/actions/messages.cljs
+++ b/src/gremllm/renderer/actions/messages.cljs
@@ -1,5 +1,6 @@
 (ns gremllm.renderer.actions.messages
-  (:require [gremllm.renderer.state.topic :as topic-state]
+  (:require [gremllm.schema :as schema]
+            [gremllm.renderer.state.topic :as topic-state]
             [gremllm.renderer.state.form :as form-state]))
 
 (defn- base-add-message-effects [topic-id message]
@@ -17,6 +18,7 @@
 
 (defn build-conversation-with-new-message
   "Builds complete conversation history including the new user message."
+  {:malli/schema [:=> [:cat :any schema/TopicId schema/Message] schema/Messages]}
   [state topic-id new-user-message]
   (let [message-history (topic-state/get-topic-field state topic-id :messages)]
     (conj (or message-history []) new-user-message)))

--- a/src/gremllm/renderer/actions/messages.cljs
+++ b/src/gremllm/renderer/actions/messages.cljs
@@ -1,7 +1,6 @@
 (ns gremllm.renderer.actions.messages
   (:require [gremllm.schema :as schema]
-            [gremllm.renderer.state.topic :as topic-state]
-            [gremllm.renderer.state.form :as form-state]))
+            [gremllm.renderer.state.topic :as topic-state]))
 
 (defn- base-add-message-effects [topic-id message]
   [[:messages.actions/append-to-state topic-id message]

--- a/src/gremllm/schema.cljs
+++ b/src/gremllm/schema.cljs
@@ -114,6 +114,7 @@
 (defn user-message
   "Constructs a UserMessage from chat input. Attaches :context only when
    anchor or excerpts are present."
+  {:malli/schema [:=> [:cat :string :any] UserMessage]}
   [text {:keys [anchor excerpts]}]
   (let [context (cond-> {}
                   anchor         (assoc :anchor anchor)
@@ -223,6 +224,7 @@
 
 (defn create-topic
   "Creates a new topic anchored to the given DocumentExcerpt."
+  {:malli/schema [:=> [:cat DocumentExcerpt] Topic]}
   [anchor]
   (assoc (m/decode Topic {} mt/default-value-transformer) :anchor anchor))
 
@@ -239,5 +241,7 @@
 
 (defn create-document-meta
   "Constructor for document metadata sent over IPC."
+  ;; Runs in the main process; label only — the renderer checker doesn't reach it.
+  {:malli/schema [:=> [:cat :string] DocumentMeta]}
   [name]
   (m/decode DocumentMeta {:name name} mt/default-value-transformer))

--- a/test/gremllm/renderer/actions/messages_test.cljs
+++ b/test/gremllm/renderer/actions/messages_test.cljs
@@ -5,11 +5,11 @@
 
 (deftest test-build-conversation-with-new-message
   (testing "builds conversation from state with new message"
-    (let [state {:topics {"t1" {:messages [{:text "first"}]}}
+    (let [state {:topics {"t1" {:messages [{:id 1 :type :user :text "first"}]}}
                  :active-topic-id "t1"}
           topic-id "t1"]
-      (is (= [{:text "first"} {:text "second"}]
-             (msg/build-conversation-with-new-message state topic-id {:text "second"}))))))
+      (is (= [{:id 1 :type :user :text "first"} {:id 2 :type :user :text "second"}]
+             (msg/build-conversation-with-new-message state topic-id {:id 2 :type :user :text "second"}))))))
 
 (deftest test-append-to-state
   (testing "returns action to append message to the active topic's messages"

--- a/test/gremllm/test_setup.cljs
+++ b/test/gremllm/test_setup.cljs
@@ -1,0 +1,26 @@
+(ns gremllm.test-setup
+  "Activates Malli function-schema instrumentation before test namespaces load.
+   Loaded as a :devtools preload for the node-test builds.
+
+   The explicit :require is load-bearing: (malli-dev/start!) collects
+   :malli/schema metadata via (ana-api/all-ns) at COMPILE time, so any
+   schema-bearing namespace not yet analyzed is silently skipped. Requiring the
+   three annotated namespaces forces them into the graph first."
+  (:require [gremllm.schema]
+            [gremllm.renderer.actions.messages]
+            [gremllm.renderer.actions.excerpt]
+            [malli.core :as m]
+            [malli.dev.cljs :as malli-dev]))
+
+(malli-dev/start!)
+
+;; Guard against the silent-no-op failure mode: if collection registered
+;; nothing, fail loudly at load instead of passing a green-but-unchecked suite.
+;; function-schemas is keyed by namespace, so count the fns across all of them.
+;; The count tracks the three required namespaces above — a :malli/schema added
+;; in a namespace not required here is silently uncovered, so add new annotation
+;; sites to the :require list.
+(let [instrumented (reduce + (map count (vals (m/function-schemas :cljs))))]
+  (assert (>= instrumented 5)
+          (str "Malli instrumentation collected " instrumented
+               " fns (<5) — schema namespaces not analyzed before start!")))

--- a/test/gremllm/test_setup.cljs
+++ b/test/gremllm/test_setup.cljs
@@ -2,25 +2,29 @@
   "Activates Malli function-schema instrumentation before test namespaces load.
    Loaded as a :devtools preload for the node-test builds.
 
-   The explicit :require is load-bearing: (malli-dev/start!) collects
-   :malli/schema metadata via (ana-api/all-ns) at COMPILE time, so any
-   schema-bearing namespace not yet analyzed is silently skipped. Requiring the
-   three annotated namespaces forces them into the graph first."
+   The explicit :require and :ns list are load-bearing: Malli collects
+   :malli/schema metadata at compile time, so schema-bearing namespaces must be
+   analyzed before instrumentation starts."
   (:require [gremllm.schema]
             [gremllm.renderer.actions.messages]
             [gremllm.renderer.actions.excerpt]
             [malli.core :as m]
             [malli.dev.cljs :as malli-dev]))
 
-(malli-dev/start!)
+(def ^:private instrumented-namespaces
+  '#{gremllm.schema
+     gremllm.renderer.actions.messages
+     gremllm.renderer.actions.excerpt})
+
+(malli-dev/start! {:ns [gremllm.schema
+                        gremllm.renderer.actions.messages
+                        gremllm.renderer.actions.excerpt]})
 
 ;; Guard against the silent-no-op failure mode: if collection registered
-;; nothing, fail loudly at load instead of passing a green-but-unchecked suite.
-;; function-schemas is keyed by namespace, so count the fns across all of them.
-;; The count tracks the three required namespaces above — a :malli/schema added
-;; in a namespace not required here is silently uncovered, so add new annotation
-;; sites to the :require list.
-(let [instrumented (reduce + (map count (vals (m/function-schemas :cljs))))]
-  (assert (>= instrumented 5)
-          (str "Malli instrumentation collected " instrumented
-               " fns (<5) — schema namespaces not analyzed before start!")))
+;; nothing for a scoped namespace, fail loudly instead of passing a
+;; green-but-unchecked suite.
+(let [schemas (m/function-schemas :cljs)
+      missing (remove #(seq (get schemas %)) instrumented-namespaces)]
+  (assert (empty? missing)
+          (str "Malli instrumentation missing schemas for "
+               (pr-str (vec missing)))))


### PR DESCRIPTION
- Annotate domain creation points in schema with Malli fn schemas for input/output validation hints
- Enable Malli fn-schema instrumentation in the renderer dev build and node-test builds
- Remove unused import in excerpt actions
- Activate instrumentation in test setup so schema violations surface during unit tests